### PR TITLE
feat: core soundbot modules via TDD

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest>=8.0.0

--- a/soundbot/__main__.py
+++ b/soundbot/__main__.py
@@ -1,0 +1,23 @@
+import logging.handlers
+
+from . import config
+from .bot import create_bot
+
+# Setup logging
+logger = logging.getLogger("soundbot")
+handler = logging.handlers.RotatingFileHandler(
+    config.LOG_FILE, maxBytes=5_000_000, backupCount=3
+)
+handler.setFormatter(
+    logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+)
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
+# Also log to console
+console = logging.StreamHandler()
+console.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+logger.addHandler(console)
+
+bot = create_bot()
+bot.run(config.DISCORD_TOKEN, log_handler=None)

--- a/soundbot/__main__.py
+++ b/soundbot/__main__.py
@@ -19,5 +19,8 @@ console = logging.StreamHandler()
 console.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
 logger.addHandler(console)
 
+if not config.DISCORD_TOKEN:
+    raise RuntimeError("DISCORD_TOKEN environment variable is required")
+
 bot = create_bot()
 bot.run(config.DISCORD_TOKEN, log_handler=None)

--- a/soundbot/audio.py
+++ b/soundbot/audio.py
@@ -17,7 +17,10 @@ def get_duration(file_path: Path) -> float:
             capture_output=True,
             text=True,
             check=True,
+            timeout=10,
         )
+    except subprocess.TimeoutExpired as exc:
+        raise ValueError("Audio file could not be processed (timed out)") from exc
     except (subprocess.CalledProcessError, FileNotFoundError) as exc:
         raise ValueError(f"Cannot read audio file: {file_path}") from exc
 

--- a/soundbot/audio.py
+++ b/soundbot/audio.py
@@ -1,0 +1,37 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+def get_duration(file_path: Path) -> float:
+    """Return the duration in seconds of an audio file using ffprobe."""
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe",
+                "-v", "error",
+                "-show_entries", "format=duration",
+                "-of", "json",
+                str(file_path),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        raise ValueError(f"Cannot read audio file: {file_path}") from exc
+
+    data = json.loads(result.stdout)
+    try:
+        return float(data["format"]["duration"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError(f"Cannot determine duration of: {file_path}") from exc
+
+
+def validate_sound(file_path: Path, max_duration: float) -> None:
+    """Raise ValueError if file is not a valid audio file or exceeds max_duration."""
+    duration = get_duration(file_path)
+    if duration > max_duration:
+        raise ValueError(
+            f"Sound duration {duration:.1f}s exceeds maximum {max_duration:.1f}s"
+        )

--- a/soundbot/bot.py
+++ b/soundbot/bot.py
@@ -1,0 +1,340 @@
+import logging
+import random
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from . import config
+from .audio import validate_sound
+from .mixer import MixerSource
+from .pagination import paginate
+from .store import SoundStore
+
+logger = logging.getLogger("soundbot")
+
+SOUNDS_PER_BOARD_PAGE = 20  # 5 rows * 5 cols - 1 row for nav = 4*5
+
+
+def _admin_check() -> app_commands.check:
+    """Check that the invoking user has the configured admin role."""
+
+    async def predicate(interaction: discord.Interaction) -> bool:
+        if not isinstance(interaction.user, discord.Member):
+            return False
+        if not any(r.name == config.ADMIN_ROLE for r in interaction.user.roles):
+            raise app_commands.MissingRole(config.ADMIN_ROLE)
+        return True
+
+    return app_commands.check(predicate)
+
+
+class Soundboard(commands.Cog):
+    def __init__(self, bot: commands.Bot, store: SoundStore) -> None:
+        self.bot = bot
+        self.store = store
+        self.mixer: MixerSource | None = None
+        self.volume: float = config.DEFAULT_VOLUME / 100.0
+
+    # -- Voice management --
+
+    @app_commands.command(name="join", description="Bot joins your voice channel")
+    @_admin_check()
+    async def join(self, interaction: discord.Interaction) -> None:
+        if not interaction.user.voice or not interaction.user.voice.channel:
+            await interaction.response.send_message(
+                "You must be in a voice channel.", ephemeral=True
+            )
+            return
+        channel = interaction.user.voice.channel
+        if interaction.guild.voice_client:
+            await interaction.guild.voice_client.move_to(channel)
+        else:
+            await channel.connect()
+        self.mixer = MixerSource()
+        await interaction.response.send_message(f"Joined **{channel.name}**.")
+
+    @app_commands.command(name="leave", description="Bot leaves the voice channel")
+    @_admin_check()
+    async def leave(self, interaction: discord.Interaction) -> None:
+        vc = interaction.guild.voice_client
+        if not vc:
+            await interaction.response.send_message(
+                "Not in a voice channel.", ephemeral=True
+            )
+            return
+        if self.mixer:
+            self.mixer.cleanup()
+            self.mixer = None
+        await vc.disconnect()
+        await interaction.response.send_message("Left the voice channel.")
+
+    # -- Playback helpers --
+
+    def _ensure_voice(self, interaction: discord.Interaction) -> discord.VoiceClient:
+        vc = interaction.guild.voice_client
+        if not vc or not vc.is_connected():
+            raise ValueError("Bot is not in a voice channel. Use `/join` first.")
+        return vc
+
+    async def _play_sound(
+        self, interaction: discord.Interaction, name: str
+    ) -> None:
+        try:
+            vc = self._ensure_voice(interaction)
+        except ValueError as exc:
+            await interaction.response.send_message(str(exc), ephemeral=True)
+            return
+
+        entry = self.store.get(name)
+        if not entry:
+            await interaction.response.send_message(
+                f"Sound **{name}** not found.", ephemeral=True
+            )
+            return
+
+        source = discord.FFmpegPCMAudio(
+            entry["file"],
+            options=f"-filter:a volume={self.volume}",
+        )
+        if self.mixer is None:
+            self.mixer = MixerSource()
+        self.mixer.add(source)
+
+        if not vc.is_playing():
+            vc.play(self.mixer)
+
+        self.store.increment_play_count(name)
+        logger.info(
+            "play sound=%s user=%s guild=%s channel=%s",
+            name,
+            interaction.user,
+            interaction.guild,
+            getattr(interaction.user.voice, "channel", None),
+        )
+        await interaction.response.send_message(
+            f"**{interaction.user.display_name}** played **{name}**"
+        )
+
+    # -- Sound name autocomplete --
+
+    async def _sound_autocomplete(
+        self, interaction: discord.Interaction, current: str
+    ) -> list[app_commands.Choice[str]]:
+        matches = self.store.search(current)
+        return [
+            app_commands.Choice(name=n, value=n) for n, _ in matches[:25]
+        ]
+
+    # -- Commands --
+
+    @app_commands.command(name="play", description="Play a sound")
+    @app_commands.describe(name="Sound name")
+    @app_commands.autocomplete(name=_sound_autocomplete)
+    @_admin_check()
+    async def play(self, interaction: discord.Interaction, name: str) -> None:
+        await self._play_sound(interaction, name)
+
+    @app_commands.command(name="random", description="Play a random sound")
+    @app_commands.describe(category="Optional category filter")
+    @_admin_check()
+    async def random_sound(
+        self, interaction: discord.Interaction, category: str | None = None
+    ) -> None:
+        sounds = self.store.list_sounds(category=category)
+        if not sounds:
+            await interaction.response.send_message(
+                "No sounds found.", ephemeral=True
+            )
+            return
+        name, _ = random.choice(sounds)
+        await self._play_sound(interaction, name)
+
+    @app_commands.command(name="volume", description="Set playback volume (0-100)")
+    @app_commands.describe(level="Volume percentage (0-100)")
+    @_admin_check()
+    async def volume(self, interaction: discord.Interaction, level: int) -> None:
+        if not 0 <= level <= 100:
+            await interaction.response.send_message(
+                "Volume must be between 0 and 100.", ephemeral=True
+            )
+            return
+        self.volume = level / 100.0
+        await interaction.response.send_message(f"Volume set to **{level}%**.")
+
+    # -- Board --
+
+    @app_commands.command(name="board", description="Show sound button board")
+    @_admin_check()
+    async def board(self, interaction: discord.Interaction) -> None:
+        sounds = self.store.list_sounds()
+        if not sounds:
+            await interaction.response.send_message(
+                "No sounds in the library.", ephemeral=True
+            )
+            return
+        pages = paginate(sounds, per_page=SOUNDS_PER_BOARD_PAGE)
+        view = BoardView(self, pages, page=0)
+        embed = view.make_embed()
+        await interaction.response.send_message(embed=embed, view=view)
+
+    # -- CRUD commands --
+
+    @app_commands.command(name="addsound", description="Add a new sound")
+    @app_commands.describe(
+        name="Sound name",
+        file="Audio file to upload",
+        category="Optional category",
+    )
+    @_admin_check()
+    async def addsound(
+        self,
+        interaction: discord.Interaction,
+        name: str,
+        file: discord.Attachment,
+        category: str | None = None,
+    ) -> None:
+        await interaction.response.defer(ephemeral=True)
+        dest = config.SOUNDS_DIR / file.filename
+        await file.save(dest)
+        try:
+            validate_sound(dest, config.MAX_DURATION)
+            self.store.add(
+                name, dest, category=category, uploaded_by=str(interaction.user)
+            )
+            self.store.save()
+        except ValueError as exc:
+            dest.unlink(missing_ok=True)
+            await interaction.followup.send(str(exc), ephemeral=True)
+            return
+        await interaction.followup.send(f"Added sound **{name}**.")
+
+    @app_commands.command(name="removesound", description="Remove a sound")
+    @app_commands.describe(name="Sound name")
+    @app_commands.autocomplete(name=_sound_autocomplete)
+    @_admin_check()
+    async def removesound(
+        self, interaction: discord.Interaction, name: str
+    ) -> None:
+        try:
+            self.store.remove(name)
+            self.store.save()
+        except KeyError:
+            await interaction.response.send_message(
+                f"Sound **{name}** not found.", ephemeral=True
+            )
+            return
+        await interaction.response.send_message(f"Removed sound **{name}**.")
+
+    @app_commands.command(name="renamesound", description="Rename a sound")
+    @app_commands.describe(old="Current name", new="New name")
+    @app_commands.autocomplete(old=_sound_autocomplete)
+    @_admin_check()
+    async def renamesound(
+        self, interaction: discord.Interaction, old: str, new: str
+    ) -> None:
+        try:
+            self.store.rename(old, new)
+            self.store.save()
+        except (KeyError, ValueError) as exc:
+            await interaction.response.send_message(str(exc), ephemeral=True)
+            return
+        await interaction.response.send_message(
+            f"Renamed **{old}** to **{new}**."
+        )
+
+    @app_commands.command(name="listsounds", description="List all sounds")
+    @app_commands.describe(category="Optional category filter")
+    @_admin_check()
+    async def listsounds(
+        self, interaction: discord.Interaction, category: str | None = None
+    ) -> None:
+        sounds = self.store.list_sounds(category=category)
+        if not sounds:
+            await interaction.response.send_message(
+                "No sounds found.", ephemeral=True
+            )
+            return
+        pages = paginate(sounds, per_page=20)
+        lines = []
+        for name, entry in pages[0]:
+            cat = entry.get("category") or "—"
+            plays = entry.get("play_count", 0)
+            lines.append(f"`{name}` | {cat} | {plays} plays")
+        embed = discord.Embed(
+            title="Sound Library",
+            description="\n".join(lines),
+        )
+        if len(pages) > 1:
+            embed.set_footer(text=f"Page 1/{len(pages)}")
+        await interaction.response.send_message(embed=embed)
+
+
+class BoardView(discord.ui.View):
+    def __init__(self, cog: Soundboard, pages, page: int = 0) -> None:
+        super().__init__(timeout=300)
+        self.cog = cog
+        self.pages = pages
+        self.page = page
+        self._build_buttons()
+
+    def _build_buttons(self) -> None:
+        self.clear_items()
+        for name, _ in self.pages[self.page]:
+            btn = discord.ui.Button(label=name, style=discord.ButtonStyle.primary)
+            btn.callback = self._make_callback(name)
+            self.add_item(btn)
+
+        if len(self.pages) > 1:
+            if self.page > 0:
+                prev_btn = discord.ui.Button(label="Previous", style=discord.ButtonStyle.secondary)
+                prev_btn.callback = self._prev
+                self.add_item(prev_btn)
+            if self.page < len(self.pages) - 1:
+                next_btn = discord.ui.Button(label="Next", style=discord.ButtonStyle.secondary)
+                next_btn.callback = self._next
+                self.add_item(next_btn)
+
+    def make_embed(self) -> discord.Embed:
+        return discord.Embed(
+            title="Soundboard",
+            description=f"Page {self.page + 1}/{len(self.pages)}",
+        )
+
+    def _make_callback(self, name: str):
+        async def callback(interaction: discord.Interaction):
+            await self.cog._play_sound(interaction, name)
+
+        return callback
+
+    async def _prev(self, interaction: discord.Interaction) -> None:
+        self.page -= 1
+        self._build_buttons()
+        await interaction.response.edit_message(embed=self.make_embed(), view=self)
+
+    async def _next(self, interaction: discord.Interaction) -> None:
+        self.page += 1
+        self._build_buttons()
+        await interaction.response.edit_message(embed=self.make_embed(), view=self)
+
+
+def create_bot() -> commands.Bot:
+    intents = discord.Intents.default()
+    intents.message_content = True
+    bot = commands.Bot(command_prefix="!", intents=intents)
+
+    store = SoundStore(
+        metadata_path=config.METADATA_FILE,
+        sounds_dir=config.SOUNDS_DIR,
+    )
+
+    @bot.event
+    async def on_ready():
+        config.SOUNDS_DIR.mkdir(parents=True, exist_ok=True)
+        store.scan_folder()
+        store.save()
+        await bot.add_cog(Soundboard(bot, store))
+        await bot.tree.sync()
+        logger.info("Bot ready as %s", bot.user)
+
+    return bot

--- a/soundbot/bot.py
+++ b/soundbot/bot.py
@@ -1,9 +1,10 @@
 import logging
 import random
+from pathlib import Path
 
 import discord
 from discord import app_commands
-from discord.ext import commands
+from discord.ext import commands, tasks
 
 from . import config
 from .audio import validate_sound
@@ -36,6 +37,18 @@ class Soundboard(commands.Cog):
         self.mixer: MixerSource | None = None
         self.volume: float = config.DEFAULT_VOLUME / 100.0
 
+    async def cog_load(self) -> None:
+        self._save_loop.start()
+
+    async def cog_unload(self) -> None:
+        self._save_loop.cancel()
+        self.store.save()
+
+    @tasks.loop(seconds=60)
+    async def _save_loop(self) -> None:
+        """Persist play counts periodically."""
+        self.store.save()
+
     # -- Voice management --
 
     @app_commands.command(name="join", description="Bot joins your voice channel")
@@ -50,8 +63,9 @@ class Soundboard(commands.Cog):
         if interaction.guild.voice_client:
             await interaction.guild.voice_client.move_to(channel)
         else:
-            await channel.connect()
-        self.mixer = MixerSource()
+            vc = await channel.connect()
+            self.mixer = MixerSource()
+            vc.play(self.mixer)
         await interaction.response.send_message(f"Joined **{channel.name}**.")
 
     @app_commands.command(name="leave", description="Bot leaves the voice channel")
@@ -64,6 +78,7 @@ class Soundboard(commands.Cog):
             )
             return
         if self.mixer:
+            self.mixer.stop()
             self.mixer.cleanup()
             self.mixer = None
         await vc.disconnect()
@@ -100,9 +115,6 @@ class Soundboard(commands.Cog):
         if self.mixer is None:
             self.mixer = MixerSource()
         self.mixer.add(source)
-
-        if not vc.is_playing():
-            vc.play(self.mixer)
 
         self.store.increment_play_count(name)
         logger.info(
@@ -195,7 +207,12 @@ class Soundboard(commands.Cog):
         category: str | None = None,
     ) -> None:
         await interaction.response.defer(ephemeral=True)
-        dest = config.SOUNDS_DIR / file.filename
+        # Sanitize filename to prevent path traversal
+        safe_name = Path(file.filename).name
+        dest = config.SOUNDS_DIR / safe_name
+        if not dest.resolve().is_relative_to(config.SOUNDS_DIR.resolve()):
+            await interaction.followup.send("Invalid filename.", ephemeral=True)
+            return
         await file.save(dest)
         try:
             validate_sound(dest, config.MAX_DURATION)
@@ -244,10 +261,16 @@ class Soundboard(commands.Cog):
         )
 
     @app_commands.command(name="listsounds", description="List all sounds")
-    @app_commands.describe(category="Optional category filter")
+    @app_commands.describe(
+        category="Optional category filter",
+        page="Page number (default 1)",
+    )
     @_admin_check()
     async def listsounds(
-        self, interaction: discord.Interaction, category: str | None = None
+        self,
+        interaction: discord.Interaction,
+        category: str | None = None,
+        page: int = 1,
     ) -> None:
         sounds = self.store.list_sounds(category=category)
         if not sounds:
@@ -256,17 +279,18 @@ class Soundboard(commands.Cog):
             )
             return
         pages = paginate(sounds, per_page=20)
+        # Clamp page to valid range
+        page_idx = max(0, min(page - 1, len(pages) - 1))
         lines = []
-        for name, entry in pages[0]:
-            cat = entry.get("category") or "—"
+        for name, entry in pages[page_idx]:
+            cat = entry.get("category") or "\u2014"
             plays = entry.get("play_count", 0)
             lines.append(f"`{name}` | {cat} | {plays} plays")
         embed = discord.Embed(
             title="Sound Library",
             description="\n".join(lines),
         )
-        if len(pages) > 1:
-            embed.set_footer(text=f"Page 1/{len(pages)}")
+        embed.set_footer(text=f"Page {page_idx + 1} of {len(pages)}")
         await interaction.response.send_message(embed=embed)
 
 
@@ -328,13 +352,22 @@ def create_bot() -> commands.Bot:
         sounds_dir=config.SOUNDS_DIR,
     )
 
-    @bot.event
-    async def on_ready():
+    async def setup_hook():
         config.SOUNDS_DIR.mkdir(parents=True, exist_ok=True)
         store.scan_folder()
         store.save()
         await bot.add_cog(Soundboard(bot, store))
-        await bot.tree.sync()
-        logger.info("Bot ready as %s", bot.user)
+        if config.SYNC_COMMANDS:
+            await bot.tree.sync()
+
+    bot.setup_hook = setup_hook
+
+    @bot.event
+    async def on_ready():
+        logger.info("Connected as %s", bot.user)
+
+    @bot.event
+    async def on_close():
+        store.save()
 
     return bot

--- a/soundbot/config.py
+++ b/soundbot/config.py
@@ -5,11 +5,11 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-DISCORD_TOKEN: str = os.environ["DISCORD_TOKEN"]
+DISCORD_TOKEN: str = os.getenv("DISCORD_TOKEN", "")
 ADMIN_ROLE: str = os.getenv("ADMIN_ROLE", "Soundbot Admin")
 SOUNDS_DIR: Path = Path(os.getenv("SOUNDS_DIR", "./sounds"))
 METADATA_FILE: Path = Path(os.getenv("METADATA_FILE", "./sounds.json"))
 DEFAULT_VOLUME: int = int(os.getenv("DEFAULT_VOLUME", "50"))
 LOG_FILE: Path = Path(os.getenv("LOG_FILE", "./soundbot.log"))
 MAX_DURATION: float = 6.0
-MAX_NAME_LENGTH: int = 32
+SYNC_COMMANDS: bool = os.getenv("SYNC_COMMANDS", "true").lower() == "true"

--- a/soundbot/mixer.py
+++ b/soundbot/mixer.py
@@ -1,0 +1,50 @@
+import struct
+
+# discord.py PCM: 48kHz, stereo, 16-bit signed LE, 20ms frames
+FRAME_SIZE = 3840  # 48000 * 2 * 2 * 0.02
+SAMPLES_PER_FRAME = FRAME_SIZE // 2
+
+
+class MixerSource:
+    """Audio source that mixes multiple sources into a single stream."""
+
+    def __init__(self) -> None:
+        self._sources: list = []
+
+    def add(self, source) -> None:
+        self._sources.append(source)
+
+    def read(self) -> bytes:
+        if not self._sources:
+            return b""
+
+        mixed = [0] * SAMPLES_PER_FRAME
+        active = []
+
+        for source in self._sources:
+            data = source.read()
+            if not data:
+                if hasattr(source, "cleanup"):
+                    source.cleanup()
+                continue
+            active.append(source)
+            samples = struct.unpack(f"<{SAMPLES_PER_FRAME}h", data)
+            for i in range(SAMPLES_PER_FRAME):
+                mixed[i] += samples[i]
+
+        self._sources = active
+
+        if not active:
+            return b""
+
+        # Clip to int16 range
+        for i in range(SAMPLES_PER_FRAME):
+            mixed[i] = max(-32768, min(32767, mixed[i]))
+
+        return struct.pack(f"<{SAMPLES_PER_FRAME}h", *mixed)
+
+    def cleanup(self) -> None:
+        for source in self._sources:
+            if hasattr(source, "cleanup"):
+                source.cleanup()
+        self._sources.clear()

--- a/soundbot/mixer.py
+++ b/soundbot/mixer.py
@@ -1,22 +1,41 @@
 import struct
 
+import discord
+
 # discord.py PCM: 48kHz, stereo, 16-bit signed LE, 20ms frames
 FRAME_SIZE = 3840  # 48000 * 2 * 2 * 0.02
 SAMPLES_PER_FRAME = FRAME_SIZE // 2
+SILENCE = b"\x00" * FRAME_SIZE
 
 
-class MixerSource:
-    """Audio source that mixes multiple sources into a single stream."""
+class MixerSource(discord.AudioSource):
+    """Audio source that mixes multiple sources into a single stream.
+
+    Returns silence when no sources are active (keeps the player alive).
+    Returns empty bytes only when explicitly stopped.
+    """
 
     def __init__(self) -> None:
         self._sources: list = []
+        self._stopped: bool = False
 
     def add(self, source) -> None:
         self._sources.append(source)
 
+    def stop(self) -> None:
+        """Signal end-of-stream. read() will return b'' after this."""
+        self._stopped = True
+
+    def reset(self) -> None:
+        """Clear stopped state so the mixer can be reused."""
+        self._stopped = False
+
     def read(self) -> bytes:
-        if not self._sources:
+        if self._stopped:
             return b""
+
+        if not self._sources:
+            return SILENCE
 
         mixed = [0] * SAMPLES_PER_FRAME
         active = []
@@ -27,6 +46,9 @@ class MixerSource:
                 if hasattr(source, "cleanup"):
                     source.cleanup()
                 continue
+            # Pad short frames with zeros
+            if len(data) < FRAME_SIZE:
+                data = data + b"\x00" * (FRAME_SIZE - len(data))
             active.append(source)
             samples = struct.unpack(f"<{SAMPLES_PER_FRAME}h", data)
             for i in range(SAMPLES_PER_FRAME):
@@ -35,7 +57,7 @@ class MixerSource:
         self._sources = active
 
         if not active:
-            return b""
+            return SILENCE
 
         # Clip to int16 range
         for i in range(SAMPLES_PER_FRAME):
@@ -48,3 +70,4 @@ class MixerSource:
             if hasattr(source, "cleanup"):
                 source.cleanup()
         self._sources.clear()
+        self._stopped = True

--- a/soundbot/pagination.py
+++ b/soundbot/pagination.py
@@ -1,0 +1,10 @@
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+def paginate(items: list[T], per_page: int) -> list[list[T]]:
+    """Split a list into pages of at most per_page items each."""
+    if not items:
+        return []
+    return [items[i : i + per_page] for i in range(0, len(items), per_page)]

--- a/soundbot/store.py
+++ b/soundbot/store.py
@@ -91,7 +91,9 @@ class SoundStore:
 
     def save(self) -> None:
         data = {"sounds": self._sounds, "version": 1}
-        self._metadata_path.write_text(json.dumps(data, indent=2))
+        tmp = self._metadata_path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(data, indent=2))
+        tmp.replace(self._metadata_path)
 
     def load(self) -> None:
         if self._metadata_path.exists():

--- a/soundbot/store.py
+++ b/soundbot/store.py
@@ -1,0 +1,124 @@
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+_MAX_NAME_LENGTH = 32
+_AUDIO_EXTS = {".mp3", ".wav", ".ogg", ".m4a", ".flac", ".opus", ".webm"}
+
+
+class SoundStore:
+    def __init__(self, metadata_path: Path, sounds_dir: Path) -> None:
+        self._metadata_path = metadata_path
+        self._sounds_dir = sounds_dir
+        self._sounds: dict[str, dict] = {}
+        self.load()
+
+    @staticmethod
+    def _validate_name(name: str) -> None:
+        if not name or len(name) > _MAX_NAME_LENGTH or not _NAME_RE.match(name):
+            raise ValueError(f"Sound name '{name}' is invalid: must be 1-{_MAX_NAME_LENGTH} alphanumeric/hyphen/underscore characters")
+
+    def add(
+        self,
+        name: str,
+        file_path: Path,
+        category: str | None = None,
+        uploaded_by: str | None = None,
+    ) -> None:
+        self._validate_name(name)
+        key = name.lower()
+        if key in self._sounds:
+            raise ValueError(f"Sound '{name}' already exists")
+        self._sounds[key] = {
+            "file": str(file_path),
+            "category": category,
+            "uploaded_by": uploaded_by,
+            "uploaded_at": datetime.now(timezone.utc).isoformat(),
+            "play_count": 0,
+        }
+
+    def rename(self, old_name: str, new_name: str) -> None:
+        self._validate_name(new_name)
+        old_key = old_name.lower()
+        new_key = new_name.lower()
+        if old_key not in self._sounds:
+            raise KeyError(f"Sound '{old_name}' not found")
+        if new_key in self._sounds:
+            raise ValueError(f"Sound '{new_name}' already exists")
+        self._sounds[new_key] = self._sounds.pop(old_key)
+
+    def remove(self, name: str) -> None:
+        key = name.lower()
+        if key not in self._sounds:
+            raise KeyError(f"Sound '{name}' not found")
+        entry = self._sounds.pop(key)
+        file_path = Path(entry["file"])
+        if file_path.exists():
+            file_path.unlink()
+
+    def get(self, name: str) -> dict | None:
+        return self._sounds.get(name.lower())
+
+    def list_sounds(self, category: str | None = None) -> list[tuple[str, dict]]:
+        results = []
+        for name, entry in self._sounds.items():
+            if category is None or entry.get("category") == category:
+                results.append((name, entry))
+        return sorted(results, key=lambda x: x[0])
+
+    def search(self, query: str) -> list[tuple[str, dict]]:
+        query_lower = query.lower()
+        if not query_lower:
+            return self.list_sounds()
+        prefix_matches = []
+        substring_matches = []
+        for name, entry in self._sounds.items():
+            if name.startswith(query_lower):
+                prefix_matches.append((name, entry))
+            elif query_lower in name:
+                substring_matches.append((name, entry))
+        prefix_matches.sort(key=lambda x: x[0])
+        substring_matches.sort(key=lambda x: x[0])
+        return prefix_matches + substring_matches
+
+    def increment_play_count(self, name: str) -> None:
+        key = name.lower()
+        if key not in self._sounds:
+            raise KeyError(f"Sound '{name}' not found")
+        self._sounds[key]["play_count"] += 1
+
+    def save(self) -> None:
+        data = {"sounds": self._sounds, "version": 1}
+        self._metadata_path.write_text(json.dumps(data, indent=2))
+
+    def load(self) -> None:
+        if self._metadata_path.exists():
+            data = json.loads(self._metadata_path.read_text())
+            self._sounds = data.get("sounds", {})
+        else:
+            self._sounds = {}
+
+    def scan_folder(self) -> None:
+        tracked_files = {entry["file"] for entry in self._sounds.values()}
+        for path in sorted(self._sounds_dir.rglob("*")):
+            if not path.is_file() or path.suffix.lower() not in _AUDIO_EXTS:
+                continue
+            if str(path) in tracked_files:
+                continue
+            name = path.stem.lower()
+            if name in self._sounds:
+                continue
+            # Infer category from subfolder (one level deep)
+            relative = path.relative_to(self._sounds_dir)
+            category = relative.parent.name if relative.parent != Path(".") else None
+            try:
+                self.add(name, path, category=category)
+            except ValueError:
+                # Invalid name from filename - skip silently
+                continue
+
+    def categories(self) -> list[str]:
+        cats = {entry["category"] for entry in self._sounds.values() if entry.get("category")}
+        return sorted(cats)

--- a/soundbot/store.py
+++ b/soundbot/store.py
@@ -103,11 +103,11 @@ class SoundStore:
             self._sounds = {}
 
     def scan_folder(self) -> None:
-        tracked_files = {entry["file"] for entry in self._sounds.values()}
+        tracked_files = {Path(entry["file"]).resolve() for entry in self._sounds.values()}
         for path in sorted(self._sounds_dir.rglob("*")):
             if not path.is_file() or path.suffix.lower() not in _AUDIO_EXTS:
                 continue
-            if str(path) in tracked_files:
+            if path.resolve() in tracked_files:
                 continue
             name = path.stem.lower()
             if name in self._sounds:

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,14 +1,14 @@
 import shutil
 import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 from soundbot.audio import get_duration, validate_sound
 
 _has_ffmpeg = shutil.which("ffprobe") is not None
-
-pytestmark = pytest.mark.skipif(not _has_ffmpeg, reason="FFmpeg/ffprobe not installed")
+_skip_no_ffmpeg = pytest.mark.skipif(not _has_ffmpeg, reason="FFmpeg/ffprobe not installed")
 
 
 @pytest.fixture()
@@ -43,12 +43,14 @@ def long_wav(tmp_path):
     return out
 
 
+@_skip_no_ffmpeg
 class TestGetDuration:
     def test_returns_correct_duration(self, short_wav):
         duration = get_duration(short_wav)
         assert 1.9 <= duration <= 2.1
 
 
+@_skip_no_ffmpeg
 class TestValidateSound:
     def test_valid_sound_passes(self, short_wav):
         # Should not raise
@@ -63,3 +65,15 @@ class TestValidateSound:
         bad_file.write_text("this is not audio")
         with pytest.raises(ValueError):
             validate_sound(bad_file, max_duration=6.0)
+
+
+class TestFfprobeTimeout:
+    """Tests that don't require ffmpeg installed."""
+
+    def test_timeout_expired_raises_valueerror(self, tmp_path):
+        fake_file = tmp_path / "stuck.mp3"
+        fake_file.write_bytes(b"fake")
+        with patch("soundbot.audio.subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired(cmd="ffprobe", timeout=10)
+            with pytest.raises(ValueError, match="timed out"):
+                get_duration(fake_file)

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,0 +1,65 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from soundbot.audio import get_duration, validate_sound
+
+_has_ffmpeg = shutil.which("ffprobe") is not None
+
+pytestmark = pytest.mark.skipif(not _has_ffmpeg, reason="FFmpeg/ffprobe not installed")
+
+
+@pytest.fixture()
+def short_wav(tmp_path):
+    """Generate a 2-second 440Hz sine wave."""
+    out = tmp_path / "short.wav"
+    subprocess.run(
+        [
+            "ffmpeg", "-y", "-f", "lavfi",
+            "-i", "sine=frequency=440:duration=2",
+            str(out),
+        ],
+        capture_output=True,
+        check=True,
+    )
+    return out
+
+
+@pytest.fixture()
+def long_wav(tmp_path):
+    """Generate a 10-second 440Hz sine wave."""
+    out = tmp_path / "long.wav"
+    subprocess.run(
+        [
+            "ffmpeg", "-y", "-f", "lavfi",
+            "-i", "sine=frequency=440:duration=10",
+            str(out),
+        ],
+        capture_output=True,
+        check=True,
+    )
+    return out
+
+
+class TestGetDuration:
+    def test_returns_correct_duration(self, short_wav):
+        duration = get_duration(short_wav)
+        assert 1.9 <= duration <= 2.1
+
+
+class TestValidateSound:
+    def test_valid_sound_passes(self, short_wav):
+        # Should not raise
+        validate_sound(short_wav, max_duration=6.0)
+
+    def test_rejects_exceeding_max_duration(self, long_wav):
+        with pytest.raises(ValueError, match="duration"):
+            validate_sound(long_wav, max_duration=6.0)
+
+    def test_rejects_non_audio_file(self, tmp_path):
+        bad_file = tmp_path / "not_audio.txt"
+        bad_file.write_text("this is not audio")
+        with pytest.raises(ValueError):
+            validate_sound(bad_file, max_duration=6.0)

--- a/tests/test_mixer.py
+++ b/tests/test_mixer.py
@@ -1,0 +1,101 @@
+import struct
+
+from soundbot.mixer import MixerSource
+
+
+# discord.py reads 20ms frames: 48000 Hz * 2 channels * 2 bytes * 0.02s = 3840 bytes
+FRAME_SIZE = 3840
+
+
+class FakeSource:
+    """A fake AudioSource that yields a fixed number of frames with a known sample value."""
+
+    def __init__(self, sample_value: int, num_frames: int = 1):
+        self._sample_value = sample_value
+        self._frames_left = num_frames
+        self.cleaned_up = False
+
+    def read(self) -> bytes:
+        if self._frames_left <= 0:
+            return b""
+        self._frames_left -= 1
+        num_samples = FRAME_SIZE // 2  # 16-bit = 2 bytes per sample
+        return struct.pack(f"<{num_samples}h", *([self._sample_value] * num_samples))
+
+    def cleanup(self):
+        self.cleaned_up = True
+
+
+class TestMixerSingleSource:
+    def test_single_source_plays_through(self):
+        mixer = MixerSource()
+        source = FakeSource(sample_value=1000, num_frames=2)
+        mixer.add(source)
+
+        frame1 = mixer.read()
+        assert len(frame1) == FRAME_SIZE
+        # Verify samples are the expected value
+        samples = struct.unpack(f"<{FRAME_SIZE // 2}h", frame1)
+        assert all(s == 1000 for s in samples)
+
+        frame2 = mixer.read()
+        assert len(frame2) == FRAME_SIZE
+
+        # Source exhausted - should return silence
+        frame3 = mixer.read()
+        assert frame3 == b""
+
+
+class TestMixerTwoSources:
+    def test_two_sources_are_summed(self):
+        mixer = MixerSource()
+        mixer.add(FakeSource(sample_value=1000, num_frames=1))
+        mixer.add(FakeSource(sample_value=2000, num_frames=1))
+
+        frame = mixer.read()
+        samples = struct.unpack(f"<{FRAME_SIZE // 2}h", frame)
+        assert all(s == 3000 for s in samples)
+
+    def test_clipping_at_int16_max(self):
+        mixer = MixerSource()
+        mixer.add(FakeSource(sample_value=30000, num_frames=1))
+        mixer.add(FakeSource(sample_value=30000, num_frames=1))
+
+        frame = mixer.read()
+        samples = struct.unpack(f"<{FRAME_SIZE // 2}h", frame)
+        # 30000 + 30000 = 60000, should clip to 32767
+        assert all(s == 32767 for s in samples)
+
+
+class TestMixerCleanup:
+    def test_finished_sources_are_cleaned_up(self):
+        mixer = MixerSource()
+        short = FakeSource(sample_value=100, num_frames=1)
+        long = FakeSource(sample_value=200, num_frames=3)
+        mixer.add(short)
+        mixer.add(long)
+
+        # Frame 1: both active
+        frame1 = mixer.read()
+        samples1 = struct.unpack(f"<{FRAME_SIZE // 2}h", frame1)
+        assert all(s == 300 for s in samples1)
+        assert not short.cleaned_up
+
+        # Frame 2: short exhausted, long still playing
+        frame2 = mixer.read()
+        samples2 = struct.unpack(f"<{FRAME_SIZE // 2}h", frame2)
+        assert all(s == 200 for s in samples2)
+        assert short.cleaned_up  # cleaned up after returning empty
+
+    def test_cleanup_stops_all_sources(self):
+        mixer = MixerSource()
+        s1 = FakeSource(sample_value=100, num_frames=10)
+        s2 = FakeSource(sample_value=200, num_frames=10)
+        mixer.add(s1)
+        mixer.add(s2)
+
+        mixer.cleanup()
+        assert s1.cleaned_up
+        assert s2.cleaned_up
+        # No more sources
+        assert mixer.read() == b""

--- a/tests/test_mixer.py
+++ b/tests/test_mixer.py
@@ -41,9 +41,10 @@ class TestMixerSingleSource:
         frame2 = mixer.read()
         assert len(frame2) == FRAME_SIZE
 
-        # Source exhausted - should return silence
+        # Source exhausted - should return silence (not empty bytes)
         frame3 = mixer.read()
-        assert frame3 == b""
+        assert len(frame3) == FRAME_SIZE
+        assert frame3 == b"\x00" * FRAME_SIZE
 
 
 class TestMixerTwoSources:
@@ -65,6 +66,62 @@ class TestMixerTwoSources:
         samples = struct.unpack(f"<{FRAME_SIZE // 2}h", frame)
         # 30000 + 30000 = 60000, should clip to 32767
         assert all(s == 32767 for s in samples)
+
+
+class TestMixerSilenceAndStop:
+    def test_returns_silence_when_no_sources_active(self):
+        """Mixer should return silence (not empty bytes) when no sources are active."""
+        mixer = MixerSource()
+        frame = mixer.read()
+        assert len(frame) == FRAME_SIZE
+        assert frame == b"\x00" * FRAME_SIZE
+
+    def test_returns_silence_after_sources_exhausted(self):
+        """After all sources finish, mixer returns silence (stays alive for more sounds)."""
+        mixer = MixerSource()
+        mixer.add(FakeSource(sample_value=1000, num_frames=1))
+        mixer.read()  # consume the one frame
+        frame = mixer.read()  # no active sources now
+        assert len(frame) == FRAME_SIZE
+        assert frame == b"\x00" * FRAME_SIZE
+
+    def test_returns_empty_when_stopped(self):
+        """Stopped mixer returns empty bytes to signal end-of-stream."""
+        mixer = MixerSource()
+        mixer.stop()
+        frame = mixer.read()
+        assert frame == b""
+
+    def test_reset_clears_stopped_state(self):
+        """reset() allows the mixer to be reused after being stopped."""
+        mixer = MixerSource()
+        mixer.stop()
+        assert mixer.read() == b""
+        mixer.reset()
+        frame = mixer.read()
+        assert len(frame) == FRAME_SIZE
+        assert frame == b"\x00" * FRAME_SIZE
+
+    def test_is_audio_source(self):
+        """MixerSource should be a discord.AudioSource subclass."""
+        import discord
+        mixer = MixerSource()
+        assert isinstance(mixer, discord.AudioSource)
+
+
+class TestMixerShortFrames:
+    def test_short_frame_is_padded(self):
+        """If a source returns fewer bytes than FRAME_SIZE, pad with zeros."""
+        mixer = MixerSource()
+
+        class ShortSource:
+            def read(self):
+                # Return a frame that's only 100 bytes (too short)
+                return b"\x01" * 100
+
+        mixer.add(ShortSource())
+        frame = mixer.read()
+        assert len(frame) == FRAME_SIZE
 
 
 class TestMixerCleanup:
@@ -97,5 +154,5 @@ class TestMixerCleanup:
         mixer.cleanup()
         assert s1.cleaned_up
         assert s2.cleaned_up
-        # No more sources
+        # Cleanup stops the mixer, so it returns empty bytes
         assert mixer.read() == b""

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,28 @@
+from soundbot.pagination import paginate
+
+
+class TestPaginate:
+    def test_splits_into_correct_pages(self):
+        items = list(range(1, 8))  # 7 items
+        pages = paginate(items, per_page=3)
+        assert len(pages) == 3
+        assert pages[0] == [1, 2, 3]
+        assert pages[1] == [4, 5, 6]
+        assert pages[2] == [7]
+
+    def test_empty_list_returns_empty(self):
+        pages = paginate([], per_page=5)
+        assert pages == []
+
+    def test_exact_fit(self):
+        items = list(range(1, 11))  # 10 items
+        pages = paginate(items, per_page=5)
+        assert len(pages) == 2
+        assert pages[0] == [1, 2, 3, 4, 5]
+        assert pages[1] == [6, 7, 8, 9, 10]
+
+    def test_single_page(self):
+        items = [1, 2, 3]
+        pages = paginate(items, per_page=10)
+        assert len(pages) == 1
+        assert pages[0] == [1, 2, 3]

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,424 @@
+from pathlib import Path
+
+import pytest
+
+from soundbot.store import SoundStore
+
+
+class TestAddAndRetrieve:
+    def test_add_sound_and_get_by_name(self, tmp_path):
+        sounds_dir = tmp_path / "sounds"
+        sounds_dir.mkdir()
+        sound_file = sounds_dir / "airhorn.mp3"
+        sound_file.write_bytes(b"fake audio data")
+
+        store = SoundStore(
+            metadata_path=tmp_path / "sounds.json",
+            sounds_dir=sounds_dir,
+        )
+        store.add("airhorn", sound_file, category="memes", uploaded_by="stuart#1234")
+
+        result = store.get("airhorn")
+        assert result is not None
+        assert result["file"] == str(sound_file)
+        assert result["category"] == "memes"
+        assert result["uploaded_by"] == "stuart#1234"
+        assert result["play_count"] == 0
+        assert "uploaded_at" in result
+
+
+class TestNameValidation:
+    def _make_store(self, tmp_path):
+        sounds_dir = tmp_path / "sounds"
+        sounds_dir.mkdir()
+        return SoundStore(
+            metadata_path=tmp_path / "sounds.json",
+            sounds_dir=sounds_dir,
+        )
+
+    def _make_file(self, tmp_path):
+        f = tmp_path / "sounds" / "test.mp3"
+        f.write_bytes(b"fake audio")
+        return f
+
+    def test_rejects_name_with_spaces(self, tmp_path):
+        store = self._make_store(tmp_path)
+        with pytest.raises(ValueError, match="invalid"):
+            store.add("air horn", self._make_file(tmp_path))
+
+    def test_rejects_name_with_special_chars(self, tmp_path):
+        store = self._make_store(tmp_path)
+        with pytest.raises(ValueError, match="invalid"):
+            store.add("air!horn", self._make_file(tmp_path))
+
+    def test_rejects_name_too_long(self, tmp_path):
+        store = self._make_store(tmp_path)
+        with pytest.raises(ValueError, match="invalid"):
+            store.add("a" * 33, self._make_file(tmp_path))
+
+    def test_allows_hyphens_and_underscores(self, tmp_path):
+        store = self._make_store(tmp_path)
+        store.add("air-horn_2", self._make_file(tmp_path))
+        assert store.get("air-horn_2") is not None
+
+    def test_rejects_duplicate_name_case_insensitive(self, tmp_path):
+        store = self._make_store(tmp_path)
+        f = self._make_file(tmp_path)
+        store.add("airhorn", f)
+        with pytest.raises(ValueError, match="already exists"):
+            store.add("AirHorn", f)
+
+
+class TestRemove:
+    def test_remove_deletes_metadata_and_file(self, tmp_path):
+        sounds_dir = tmp_path / "sounds"
+        sounds_dir.mkdir()
+        sound_file = sounds_dir / "airhorn.mp3"
+        sound_file.write_bytes(b"fake audio data")
+
+        store = SoundStore(
+            metadata_path=tmp_path / "sounds.json",
+            sounds_dir=sounds_dir,
+        )
+        store.add("airhorn", sound_file)
+        store.remove("airhorn")
+
+        assert store.get("airhorn") is None
+        assert not sound_file.exists()
+
+    def test_remove_nonexistent_raises(self, tmp_path):
+        sounds_dir = tmp_path / "sounds"
+        sounds_dir.mkdir()
+        store = SoundStore(
+            metadata_path=tmp_path / "sounds.json",
+            sounds_dir=sounds_dir,
+        )
+        with pytest.raises(KeyError):
+            store.remove("nope")
+
+
+class TestRename:
+    def test_rename_moves_metadata_keeps_file(self, tmp_path):
+        sounds_dir = tmp_path / "sounds"
+        sounds_dir.mkdir()
+        sound_file = sounds_dir / "airhorn.mp3"
+        sound_file.write_bytes(b"fake audio data")
+
+        store = SoundStore(
+            metadata_path=tmp_path / "sounds.json",
+            sounds_dir=sounds_dir,
+        )
+        store.add("airhorn", sound_file, category="memes")
+        store.rename("airhorn", "klaxon")
+
+        assert store.get("airhorn") is None
+        assert store.get("klaxon") is not None
+        assert store.get("klaxon")["file"] == str(sound_file)
+        assert store.get("klaxon")["category"] == "memes"
+        assert sound_file.exists()
+
+    def test_rename_validates_new_name(self, tmp_path):
+        sounds_dir = tmp_path / "sounds"
+        sounds_dir.mkdir()
+        sound_file = sounds_dir / "airhorn.mp3"
+        sound_file.write_bytes(b"fake audio data")
+
+        store = SoundStore(
+            metadata_path=tmp_path / "sounds.json",
+            sounds_dir=sounds_dir,
+        )
+        store.add("airhorn", sound_file)
+        with pytest.raises(ValueError, match="invalid"):
+            store.rename("airhorn", "bad name!")
+
+
+class TestListSounds:
+    def test_list_all_sounds(self, tmp_path):
+        sounds_dir = tmp_path / "sounds"
+        sounds_dir.mkdir()
+        f1 = sounds_dir / "airhorn.mp3"
+        f1.write_bytes(b"fake")
+        f2 = sounds_dir / "rimshot.mp3"
+        f2.write_bytes(b"fake")
+
+        store = SoundStore(
+            metadata_path=tmp_path / "sounds.json",
+            sounds_dir=sounds_dir,
+        )
+        store.add("airhorn", f1, category="memes")
+        store.add("rimshot", f2, category="comedy")
+
+        result = store.list_sounds()
+        names = [s[0] for s in result]
+        assert "airhorn" in names
+        assert "rimshot" in names
+        assert len(result) == 2
+
+    def test_list_filtered_by_category(self, tmp_path):
+        sounds_dir = tmp_path / "sounds"
+        sounds_dir.mkdir()
+        f1 = sounds_dir / "airhorn.mp3"
+        f1.write_bytes(b"fake")
+        f2 = sounds_dir / "rimshot.mp3"
+        f2.write_bytes(b"fake")
+
+        store = SoundStore(
+            metadata_path=tmp_path / "sounds.json",
+            sounds_dir=sounds_dir,
+        )
+        store.add("airhorn", f1, category="memes")
+        store.add("rimshot", f2, category="comedy")
+
+        result = store.list_sounds(category="memes")
+        assert len(result) == 1
+        assert result[0][0] == "airhorn"
+
+    def test_categories_returns_distinct(self, tmp_path):
+        sounds_dir = tmp_path / "sounds"
+        sounds_dir.mkdir()
+        f1 = sounds_dir / "a.mp3"
+        f1.write_bytes(b"fake")
+        f2 = sounds_dir / "b.mp3"
+        f2.write_bytes(b"fake")
+        f3 = sounds_dir / "c.mp3"
+        f3.write_bytes(b"fake")
+
+        store = SoundStore(
+            metadata_path=tmp_path / "sounds.json",
+            sounds_dir=sounds_dir,
+        )
+        store.add("a", f1, category="memes")
+        store.add("b", f2, category="memes")
+        store.add("c", f3, category="comedy")
+
+        cats = store.categories()
+        assert set(cats) == {"memes", "comedy"}
+
+
+class TestSearch:
+    def test_search_exact_prefix_ranked_first(self, tmp_path):
+        sounds_dir = tmp_path / "sounds"
+        sounds_dir.mkdir()
+        for name in ["airhorn", "air-raid", "foghorn", "airbag"]:
+            f = sounds_dir / f"{name}.mp3"
+            f.write_bytes(b"fake")
+
+        store = SoundStore(
+            metadata_path=tmp_path / "sounds.json",
+            sounds_dir=sounds_dir,
+        )
+        for name in ["airhorn", "air-raid", "foghorn", "airbag"]:
+            store.add(name, sounds_dir / f"{name}.mp3")
+
+        results = store.search("air")
+        names = [r[0] for r in results]
+        # All "air*" names should come back; "foghorn" should not
+        assert "airhorn" in names
+        assert "air-raid" in names
+        assert "airbag" in names
+        assert "foghorn" not in names
+
+    def test_search_substring_match(self, tmp_path):
+        sounds_dir = tmp_path / "sounds"
+        sounds_dir.mkdir()
+        for name in ["airhorn", "foghorn", "rimshot"]:
+            f = sounds_dir / f"{name}.mp3"
+            f.write_bytes(b"fake")
+
+        store = SoundStore(
+            metadata_path=tmp_path / "sounds.json",
+            sounds_dir=sounds_dir,
+        )
+        for name in ["airhorn", "foghorn", "rimshot"]:
+            store.add(name, sounds_dir / f"{name}.mp3")
+
+        results = store.search("horn")
+        names = [r[0] for r in results]
+        assert "airhorn" in names
+        assert "foghorn" in names
+        assert "rimshot" not in names
+
+    def test_search_case_insensitive(self, tmp_path):
+        sounds_dir = tmp_path / "sounds"
+        sounds_dir.mkdir()
+        f = sounds_dir / "airhorn.mp3"
+        f.write_bytes(b"fake")
+
+        store = SoundStore(
+            metadata_path=tmp_path / "sounds.json",
+            sounds_dir=sounds_dir,
+        )
+        store.add("airhorn", f)
+
+        results = store.search("AIR")
+        assert len(results) >= 1
+        assert results[0][0] == "airhorn"
+
+    def test_search_empty_query_returns_all(self, tmp_path):
+        sounds_dir = tmp_path / "sounds"
+        sounds_dir.mkdir()
+        f = sounds_dir / "airhorn.mp3"
+        f.write_bytes(b"fake")
+
+        store = SoundStore(
+            metadata_path=tmp_path / "sounds.json",
+            sounds_dir=sounds_dir,
+        )
+        store.add("airhorn", f)
+
+        results = store.search("")
+        assert len(results) == 1
+
+
+class TestPlayCount:
+    def test_increment_play_count(self, tmp_path):
+        sounds_dir = tmp_path / "sounds"
+        sounds_dir.mkdir()
+        f = sounds_dir / "airhorn.mp3"
+        f.write_bytes(b"fake")
+
+        store = SoundStore(
+            metadata_path=tmp_path / "sounds.json",
+            sounds_dir=sounds_dir,
+        )
+        store.add("airhorn", f)
+        assert store.get("airhorn")["play_count"] == 0
+
+        store.increment_play_count("airhorn")
+        assert store.get("airhorn")["play_count"] == 1
+
+        store.increment_play_count("airhorn")
+        store.increment_play_count("airhorn")
+        assert store.get("airhorn")["play_count"] == 3
+
+    def test_increment_nonexistent_raises(self, tmp_path):
+        sounds_dir = tmp_path / "sounds"
+        sounds_dir.mkdir()
+        store = SoundStore(
+            metadata_path=tmp_path / "sounds.json",
+            sounds_dir=sounds_dir,
+        )
+        with pytest.raises(KeyError):
+            store.increment_play_count("nope")
+
+
+class TestPersistence:
+    def test_save_and_load_roundtrip(self, tmp_path):
+        sounds_dir = tmp_path / "sounds"
+        sounds_dir.mkdir()
+        f = sounds_dir / "airhorn.mp3"
+        f.write_bytes(b"fake audio data")
+        metadata_path = tmp_path / "sounds.json"
+
+        store = SoundStore(metadata_path=metadata_path, sounds_dir=sounds_dir)
+        store.add("airhorn", f, category="memes", uploaded_by="stuart#1234")
+        store.increment_play_count("airhorn")
+        store.save()
+
+        # Load into a new store instance
+        store2 = SoundStore(metadata_path=metadata_path, sounds_dir=sounds_dir)
+        result = store2.get("airhorn")
+        assert result is not None
+        assert result["file"] == str(f)
+        assert result["category"] == "memes"
+        assert result["uploaded_by"] == "stuart#1234"
+        assert result["play_count"] == 1
+
+    def test_load_nonexistent_file_starts_empty(self, tmp_path):
+        sounds_dir = tmp_path / "sounds"
+        sounds_dir.mkdir()
+        store = SoundStore(
+            metadata_path=tmp_path / "sounds.json",
+            sounds_dir=sounds_dir,
+        )
+        assert store.list_sounds() == []
+
+    def test_save_creates_valid_json_with_version(self, tmp_path):
+        import json
+
+        sounds_dir = tmp_path / "sounds"
+        sounds_dir.mkdir()
+        f = sounds_dir / "airhorn.mp3"
+        f.write_bytes(b"fake")
+        metadata_path = tmp_path / "sounds.json"
+
+        store = SoundStore(metadata_path=metadata_path, sounds_dir=sounds_dir)
+        store.add("airhorn", f)
+        store.save()
+
+        data = json.loads(metadata_path.read_text())
+        assert "sounds" in data
+        assert "version" in data
+        assert data["version"] == 1
+        assert "airhorn" in data["sounds"]
+
+
+class TestFolderScan:
+    def test_scan_imports_untracked_files(self, tmp_path):
+        sounds_dir = tmp_path / "sounds"
+        sounds_dir.mkdir()
+        (sounds_dir / "airhorn.mp3").write_bytes(b"fake")
+        (sounds_dir / "rimshot.wav").write_bytes(b"fake")
+
+        store = SoundStore(
+            metadata_path=tmp_path / "sounds.json",
+            sounds_dir=sounds_dir,
+        )
+        store.scan_folder()
+
+        assert store.get("airhorn") is not None
+        assert store.get("rimshot") is not None
+        assert store.get("airhorn")["category"] is None
+
+    def test_scan_infers_category_from_subfolder(self, tmp_path):
+        sounds_dir = tmp_path / "sounds"
+        sounds_dir.mkdir()
+        memes_dir = sounds_dir / "memes"
+        memes_dir.mkdir()
+        (memes_dir / "airhorn.mp3").write_bytes(b"fake")
+
+        store = SoundStore(
+            metadata_path=tmp_path / "sounds.json",
+            sounds_dir=sounds_dir,
+        )
+        store.scan_folder()
+
+        result = store.get("airhorn")
+        assert result is not None
+        assert result["category"] == "memes"
+
+    def test_scan_skips_already_tracked(self, tmp_path):
+        sounds_dir = tmp_path / "sounds"
+        sounds_dir.mkdir()
+        f = sounds_dir / "airhorn.mp3"
+        f.write_bytes(b"fake")
+
+        store = SoundStore(
+            metadata_path=tmp_path / "sounds.json",
+            sounds_dir=sounds_dir,
+        )
+        store.add("airhorn", f, category="custom")
+        store.scan_folder()
+
+        # Category should remain "custom", not be overwritten
+        assert store.get("airhorn")["category"] == "custom"
+
+    def test_scan_handles_duplicate_filenames_in_subfolders(self, tmp_path):
+        """If memes/airhorn.mp3 and sfx/airhorn.mp3 both exist, only first is imported."""
+        sounds_dir = tmp_path / "sounds"
+        sounds_dir.mkdir()
+        memes = sounds_dir / "memes"
+        memes.mkdir()
+        sfx = sounds_dir / "sfx"
+        sfx.mkdir()
+        (memes / "airhorn.mp3").write_bytes(b"fake")
+        (sfx / "airhorn.mp3").write_bytes(b"fake")
+
+        store = SoundStore(
+            metadata_path=tmp_path / "sounds.json",
+            sounds_dir=sounds_dir,
+        )
+        store.scan_folder()
+
+        # Should have imported one, not crashed
+        assert store.get("airhorn") is not None

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -422,3 +422,33 @@ class TestFolderScan:
 
         # Should have imported one, not crashed
         assert store.get("airhorn") is not None
+
+    def test_scan_skips_file_tracked_under_different_path_form(self, tmp_path):
+        """scan_folder should not re-import a file stored with a different path string form.
+
+        If the file is tracked under a relative path like 'sounds/airhorn.mp3'
+        but scan_folder sees the absolute path, it should recognize they're the same file.
+        """
+        sounds_dir = tmp_path / "sounds"
+        sounds_dir.mkdir()
+        sound_file = sounds_dir / "airhorn.mp3"
+        sound_file.write_bytes(b"fake")
+
+        store = SoundStore(
+            metadata_path=tmp_path / "sounds.json",
+            sounds_dir=sounds_dir,
+        )
+        # Add the sound with a custom name (different from stem) so name check doesn't shortcut
+        store.add("my-horn", sound_file, category="custom")
+        # Overwrite the stored file path to use the un-resolved form
+        # (e.g., includes ../ or different casing on Windows)
+        alt_path = sounds_dir / ".." / "sounds" / "airhorn.mp3"
+        store._sounds["my-horn"]["file"] = str(alt_path)
+
+        # scan_folder should recognize this file is already tracked
+        store.scan_folder()
+
+        # The file should NOT be re-imported under its stem name "airhorn"
+        # because it's already tracked (just under a different path form)
+        assert store.get("airhorn") is None
+        assert len(store.list_sounds()) == 1


### PR DESCRIPTION
## Summary
- **SoundStore** — JSON-backed metadata store with full CRUD, fuzzy search, folder scan, play count tracking
- **Audio utils** — FFprobe-based duration validation (≤6s limit)  
- **MixerSource** — Custom discord.py AudioSource that mixes unlimited overlapping sounds in real time (PCM summing with int16 clipping)
- **Pagination** — Generic paginator for /board and /listsounds
- **Bot** — All 10 slash commands (/join, /leave, /play, /random, /board, /volume, /addsound, /removesound, /renamesound, /listsounds) with admin role gating, fuzzy autocomplete, and paginated button boards
- **Entry point** — `python -m soundbot` runner with startup folder scan and logging setup

## Tests
35 passing, 4 skipped (audio tests require FFmpeg — pass in Docker)

## Test plan
- [x] All pytest tests pass
- [ ] Manual test: create Discord bot app, set token, run in Docker, verify slash commands register
- [ ] Manual test: upload sounds, play them, test mixing/overlap
- [ ] Manual test: verify admin role gating blocks unauthorized users

🤖 Generated with [Claude Code](https://claude.com/claude-code)