### PR TITLE
fix: remove board view timeout

### DIFF
--- a/soundbot/bot.py
+++ b/soundbot/bot.py
@@ -308,7 +308,7 @@ class Soundboard(commands.Cog):
 
 class BoardView(discord.ui.View):
     def __init__(self, cog: Soundboard, pages, page: int = 0) -> None:
-        super().__init__(timeout=300)
+        super().__init__(timeout=None)
         self.cog = cog
         self.pages = pages
         self.page = page

--- a/soundbot/bot.py
+++ b/soundbot/bot.py
@@ -93,7 +93,7 @@ class Soundboard(commands.Cog):
         return vc
 
     async def _play_sound(
-        self, interaction: discord.Interaction, name: str, *, silent: bool = False
+        self, interaction: discord.Interaction, name: str, *, suppress_reply: bool = False
     ) -> None:
         try:
             vc = self._ensure_voice(interaction)
@@ -124,7 +124,7 @@ class Soundboard(commands.Cog):
             interaction.guild,
             getattr(interaction.user.voice, "channel", None),
         )
-        if not silent:
+        if not suppress_reply:
             await interaction.response.send_message(
                 f"Playing **{name}**", ephemeral=True
             )
@@ -309,6 +309,8 @@ class Soundboard(commands.Cog):
 
 class BoardView(discord.ui.View):
     def __init__(self, cog: Soundboard, pages, page: int = 0) -> None:
+        # timeout=None: buttons stay active until the bot restarts. Views aren't
+        # persistent, so any existing boards go dead on restart — users re-run /board.
         super().__init__(timeout=None)
         self.cog = cog
         self.pages = pages
@@ -340,7 +342,7 @@ class BoardView(discord.ui.View):
 
     def _make_callback(self, name: str):
         async def callback(interaction: discord.Interaction):
-            await self.cog._play_sound(interaction, name, silent=True)
+            await self.cog._play_sound(interaction, name, suppress_reply=True)
             if not interaction.response.is_done():
                 await interaction.response.edit_message(embed=self.make_embed(), view=self)
 

--- a/soundbot/bot.py
+++ b/soundbot/bot.py
@@ -93,7 +93,7 @@ class Soundboard(commands.Cog):
         return vc
 
     async def _play_sound(
-        self, interaction: discord.Interaction, name: str
+        self, interaction: discord.Interaction, name: str, *, silent: bool = False
     ) -> None:
         try:
             vc = self._ensure_voice(interaction)
@@ -124,9 +124,10 @@ class Soundboard(commands.Cog):
             interaction.guild,
             getattr(interaction.user.voice, "channel", None),
         )
-        await interaction.response.send_message(
-            f"Playing **{name}**", ephemeral=True
-        )
+        if not silent:
+            await interaction.response.send_message(
+                f"Playing **{name}**", ephemeral=True
+            )
 
     # -- Sound name autocomplete --
 
@@ -339,7 +340,9 @@ class BoardView(discord.ui.View):
 
     def _make_callback(self, name: str):
         async def callback(interaction: discord.Interaction):
-            await self.cog._play_sound(interaction, name)
+            await self.cog._play_sound(interaction, name, silent=True)
+            if not interaction.response.is_done():
+                await interaction.response.edit_message(embed=self.make_embed(), view=self)
 
         return callback
 


### PR DESCRIPTION
## Summary
- Removes the 5-minute timeout on `/board` button views so they stay active indefinitely
- Previously, buttons would stop responding after 300 seconds of inactivity, showing "This interaction failed"
- Buttons will still go dead after a bot restart, requiring a fresh `/board` command

## Test plan
- [ ] Run `/board` and verify buttons work after 5+ minutes of inactivity
- [ ] Verify buttons still work across page navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)