### PR TITLE
Add loudness normalization scripts

### DIFF
--- a/scripts/diff_loudness.py
+++ b/scripts/diff_loudness.py
@@ -1,0 +1,61 @@
+"""Show the before/after loudness diff for each file.
+
+Flags any reduced file that didn't land within 0.5 dB of target.
+
+Usage:  python scripts/diff_loudness.py <before.tsv> <after.tsv> <target_lufs>
+"""
+import sys
+from pathlib import Path
+
+
+def load(path: Path) -> dict[str, tuple[float, float]]:
+    out: dict[str, tuple[float, float]] = {}
+    for line in path.read_text().splitlines():
+        if not line.strip():
+            continue
+        name, lufs_s, peak_s = line.split("\t")
+        out[name] = (float(lufs_s), float(peak_s))
+    return out
+
+
+def main() -> int:
+    before = load(Path(sys.argv[1]))
+    after = load(Path(sys.argv[2]))
+    target = float(sys.argv[3])
+
+    print(f"{'file':<40} {'before':>8} {'after':>8} {'diff':>7} {'flag':>6}")
+    print("-" * 75)
+
+    off_target: list[tuple[str, float]] = []
+    untouched_above: list[tuple[str, float]] = []
+
+    # Sort by before-loudness descending
+    for name in sorted(before.keys(), key=lambda n: before[n][0], reverse=True):
+        b_lufs, _ = before[name]
+        if name not in after:
+            print(f"{name:<40} {b_lufs:>8.1f}     MISSING")
+            continue
+        a_lufs, _ = after[name]
+        delta = a_lufs - b_lufs
+        flag = ""
+        if b_lufs > target:  # should have been reduced
+            if abs(a_lufs - target) > 0.5:
+                flag = "OFF"
+                off_target.append((name, a_lufs))
+        else:  # should be untouched
+            if abs(delta) > 0.1:
+                flag = "MOVED"
+        print(f"{name:<40} {b_lufs:>8.1f} {a_lufs:>8.1f} {delta:>+7.1f} {flag:>6}")
+
+    print("-" * 75)
+    if off_target:
+        print(f"\n{len(off_target)} files didn't land within 0.5 dB of target:")
+        for n, l in off_target:
+            print(f"  {n}: {l:.1f} LUFS (target {target})")
+        return 1
+    print("\nAll reduced files landed within 0.5 dB of target.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/measure_loudness.py
+++ b/scripts/measure_loudness.py
@@ -1,0 +1,51 @@
+"""One-shot helper: measure integrated loudness + true peak of every file in sounds/.
+
+Run from repo root:  python scripts/measure_loudness.py
+Prints one line per file: `filename<TAB>LUFS<TAB>true_peak_dbfs`
+"""
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+SOUNDS_DIR = Path(__file__).resolve().parent.parent / "sounds"
+I_RE = re.compile(r"Integrated loudness:\s*\n\s*I:\s*(-?\d+\.\d+) LUFS")
+TP_RE = re.compile(r"True peak:\s*\n\s*Peak:\s*(-?\d+\.\d+) dBFS")
+
+
+def measure(path: Path) -> tuple[float, float] | None:
+    result = subprocess.run(
+        [
+            "ffmpeg", "-nostats", "-hide_banner",
+            "-i", str(path),
+            "-af", "ebur128=peak=true",
+            "-f", "null", "-",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    out = result.stderr
+    i_match = I_RE.search(out)
+    tp_match = TP_RE.search(out)
+    if not i_match or not tp_match:
+        return None
+    return float(i_match.group(1)), float(tp_match.group(1))
+
+
+def main() -> int:
+    files = sorted(
+        p for p in SOUNDS_DIR.iterdir()
+        if p.is_file() and p.suffix.lower() in {".ogg", ".mp3", ".wav", ".m4a", ".flac", ".opus"}
+    )
+    for path in files:
+        m = measure(path)
+        if m is None:
+            print(f"{path.name}\tERROR\tERROR", file=sys.stderr)
+            continue
+        lufs, peak = m
+        print(f"{path.name}\t{lufs}\t{peak}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/normalize_loudness.py
+++ b/scripts/normalize_loudness.py
@@ -1,0 +1,115 @@
+"""Normalize the loud sounds in sounds/ down to a target LUFS.
+
+Only applies *negative* gain — any file quieter than the target is left alone
+(avoids amplifying noise floor and removes clipping risk entirely).
+
+Reads the pre-measurement TSV produced by scripts/measure_loudness.py so we
+don't re-measure (that was already expensive).
+
+Re-encodes in place via a temp file → atomic replace:
+  - .ogg  -> libopus  96 kbps  (source is 48kHz stereo Opus already)
+  - .mp3  -> libmp3lame 128 kbps CBR (matches source)
+
+Run from repo root:  python scripts/normalize_loudness.py <measurements.tsv> <target_lufs>
+"""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SOUNDS_DIR = Path(__file__).resolve().parent.parent / "sounds"
+SKIP_THRESHOLD_DB = 0.3  # don't bother re-encoding for sub-threshold trims
+
+
+def encode_args(ext: str) -> list[str]:
+    ext = ext.lower()
+    if ext == ".ogg":
+        return ["-c:a", "libopus", "-b:a", "96k", "-vbr", "on"]
+    if ext == ".mp3":
+        return ["-c:a", "libmp3lame", "-b:a", "128k"]
+    raise ValueError(f"Unsupported extension: {ext}")
+
+
+def apply_gain(path: Path, gain_db: float) -> None:
+    tmp = path.with_name(path.stem + ".__norm_tmp__" + path.suffix)
+    cmd = [
+        "ffmpeg", "-y", "-nostats", "-hide_banner",
+        "-i", str(path),
+        "-af", f"volume={gain_db:.2f}dB",
+        *encode_args(path.suffix),
+        str(tmp),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        tmp.unlink(missing_ok=True)
+        raise RuntimeError(f"ffmpeg failed on {path.name}:\n{result.stderr}")
+    os.replace(tmp, path)
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: normalize_loudness.py <measurements.tsv> <target_lufs>", file=sys.stderr)
+        return 2
+
+    measurements_path = Path(sys.argv[1])
+    target_lufs = float(sys.argv[2])
+
+    rows: list[tuple[str, float, float]] = []
+    for line in measurements_path.read_text().splitlines():
+        if not line.strip():
+            continue
+        name, lufs_s, peak_s = line.split("\t")
+        rows.append((name, float(lufs_s), float(peak_s)))
+
+    reduced = 0
+    skipped_quiet = 0
+    skipped_near_target = 0
+    errors: list[str] = []
+
+    # Sort by how much we're reducing, loudest first — most dramatic at top
+    rows.sort(key=lambda r: r[1], reverse=True)
+
+    print(f"Target: {target_lufs:.1f} LUFS")
+    print(f"{'file':<40}  {'before':>8}  {'gain':>7}")
+    print("-" * 60)
+
+    for name, lufs, _peak in rows:
+        path = SOUNDS_DIR / name
+        if not path.exists():
+            errors.append(f"{name}: missing file")
+            continue
+
+        if lufs <= target_lufs:
+            skipped_quiet += 1
+            continue
+
+        gain = target_lufs - lufs
+        if abs(gain) < SKIP_THRESHOLD_DB:
+            skipped_near_target += 1
+            print(f"{name:<40}  {lufs:>7.1f}   (skip, within {SKIP_THRESHOLD_DB} dB)")
+            continue
+
+        try:
+            apply_gain(path, gain)
+        except RuntimeError as exc:
+            errors.append(str(exc))
+            print(f"{name:<40}  ERROR")
+            continue
+
+        print(f"{name:<40}  {lufs:>7.1f}  {gain:>+6.1f} dB")
+        reduced += 1
+
+    print("-" * 60)
+    print(f"Reduced:           {reduced}")
+    print(f"Skipped (quieter): {skipped_quiet}")
+    print(f"Skipped (at target within {SKIP_THRESHOLD_DB} dB): {skipped_near_target}")
+    if errors:
+        print(f"Errors ({len(errors)}):")
+        for e in errors:
+            print(f"  {e}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds three utility scripts for measuring and normalizing sound library loudness against a reference clip
- `measure_loudness.py` — prints integrated LUFS and true peak per file via ffmpeg's `ebur128` filter
- `normalize_loudness.py` — applies negative gain only (never boosts) so there's no clipping risk and no noise-floor amplification for quiet clips
- `diff_loudness.py` — compares before/after measurements and flags any file that missed the target by more than 0.5 dB

## Context

Used to quieten 38 loud clips in the library down to `feedable.ogg`'s -25.2 LUFS. Previously the library ranged from -34 LUFS (forwardtowife) to -4.5 LUFS (will_angy) — about a 30 dB spread. Post-normalization the loud outliers land within 0.5 dB of target and the naturally quieter clips are untouched.

Re-encodes in place via a temp file / atomic replace. `.ogg` files re-encode to libopus 96 kbps (the source is already 48 kHz stereo Opus); `.mp3` files re-encode to libmp3lame 128 kbps CBR.

No changes to the bot itself — `soundbot/`, tests, config, and Docker are all untouched. Sound files are gitignored so the actual audio changes live outside the repo.

## Test plan

- [x] Measured all 55 files before normalization
- [x] Normalized 38 loud files; 17 quieter clips left alone
- [x] Re-measured and confirmed every reduced file landed within 0.5 dB of -25.2 LUFS target
- [x] Verified `feedable.ogg` (reference) is byte-for-byte unchanged
- [x] Physical backup of originals retained at `soundbot-backups/sounds-pre-normalize-20260411-225312/`
- [ ] Play a normalized clip in Discord and confirm it sounds as expected

Generated with [Claude Code](https://claude.com/claude-code)