### PR TITLE
perf: decode sounds once and cache PCM in memory (closes #16)

### DIFF
--- a/soundbot/bot.py
+++ b/soundbot/bot.py
@@ -335,15 +335,28 @@ class Soundboard(commands.Cog):
     def _find_existing_by_path(self, path: Path) -> str | None:
         """Return the name of any store entry whose file is `path`, or None.
 
-        Used by addsound to refuse an upload that would silently overwrite
-        another sound's file. Pre-fix bug: two sounds with the same
-        uploaded filename (different names) would both land at the same
-        dest on disk. The second upload would clobber the first's bytes,
-        corrupting the first entry even though no exception was raised.
+        Used by addsound and importsounds to refuse a write that would
+        silently overwrite another sound's file. Pre-fix bug: two sounds
+        with the same destination filename (different names) would both
+        land at the same path on disk. The second write would clobber the
+        first's bytes, corrupting the first entry without raising.
+
+        Both sides are resolved to absolute paths before comparison so a
+        relative-vs-absolute mismatch (e.g. `SOUNDS_DIR=sounds` in config
+        vs `sounds/foo.mp3` already stored absolutely) doesn't defeat the
+        check. `.resolve(strict=False)` doesn't raise on missing files,
+        but we still guard against OSError on path encoding edge cases.
         """
+        try:
+            target = Path(path).resolve(strict=False)
+        except OSError:
+            return None
         for existing_name, existing_entry in self.store.list_sounds():
-            if Path(existing_entry["file"]) == path:
-                return existing_name
+            try:
+                if Path(existing_entry["file"]).resolve(strict=False) == target:
+                    return existing_name
+            except OSError:
+                continue
         return None
 
     @app_commands.command(name="addsound", description="Add a new sound")
@@ -534,6 +547,7 @@ class Soundboard(commands.Cog):
         tagged_existing = []
         already_tagged = []
         file_conflict = []
+        path_conflict = []
         failed = []
         for sound in sounds:
             try:
@@ -555,7 +569,14 @@ class Soundboard(commands.Cog):
             if bucket == "file_conflict":
                 file_conflict.append(key)
                 continue
-            # bucket == "needs_download"
+            # bucket == "needs_download". Even though `key` doesn't have a
+            # store entry, the dest path could still be owned by an entry
+            # under a different name (dangling pointer, manual JSON edit,
+            # etc.). Don't silently overwrite — same guard addsound uses.
+            other_owner = self._find_existing_by_path(dest)
+            if other_owner is not None:
+                path_conflict.append(f"{key} (owned by '{other_owner}')")
+                continue
             try:
                 await sound.save(dest)
                 validate_sound(dest, config.MAX_DURATION)
@@ -592,6 +613,11 @@ class Soundboard(commands.Cog):
             names = ", ".join(file_conflict)
             parts.append(
                 f"File conflict {len(file_conflict)} (a different file with that name exists on disk): {names}"
+            )
+        if path_conflict:
+            names = ", ".join(path_conflict)
+            parts.append(
+                f"Path conflict {len(path_conflict)} (another sound entry already owns that file): {names}"
             )
         if failed:
             parts.append(f"Failed {len(failed)}: {', '.join(failed)}")

--- a/soundbot/bot.py
+++ b/soundbot/bot.py
@@ -174,9 +174,23 @@ class Soundboard(commands.Cog):
             )
             return
 
+        # The to_thread await above is a yield point: a concurrent /leave can
+        # tear down the mixer and disconnect the voice client before we get
+        # back here. Re-check before touching self.mixer — otherwise we'd
+        # silently drop the sound and leak an orphan mixer.
+        if self.mixer is None or not vc.is_connected():
+            logger.info("voice torn down during decode, dropping sound=%s", name)
+            if not interaction.response.is_done():
+                try:
+                    await interaction.response.send_message(
+                        "Voice connection lost while loading sound.",
+                        ephemeral=True,
+                    )
+                except discord.HTTPException:
+                    pass
+            return
+
         source = CachedPCMSource(pcm_bytes)
-        if self.mixer is None:
-            self.mixer = MixerSource(volume=self.volume)
         self.mixer.add(source)
 
         self.store.increment_play_count(name)
@@ -362,6 +376,11 @@ class Soundboard(commands.Cog):
                 dest.unlink(missing_ok=True)
                 dest = audio_dest
             validate_sound(dest, config.MAX_DURATION)
+            # Drop any stale cached PCM for this path before the new entry
+            # is added. Two distinct sound names uploaded with the same
+            # filename land at the same dest on disk, and a previous /play
+            # may have populated the cache with the old file's bytes.
+            self.pcm_cache.invalidate(dest)
             self.store.add(
                 name, dest, category=category, uploaded_by=str(interaction.user)
             )
@@ -408,6 +427,10 @@ class Soundboard(commands.Cog):
     async def renamesound(
         self, interaction: discord.Interaction, old: str, new: str
     ) -> None:
+        # No pcm_cache interaction needed: store.rename swaps the dict key
+        # in metadata but leaves the file on disk at the same path, and the
+        # cache is keyed by file path. The same bytes are still correct
+        # under the new name.
         try:
             self.store.rename(old, new)
             self.store.save()

--- a/soundbot/bot.py
+++ b/soundbot/bot.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import random
 from pathlib import Path
@@ -11,6 +12,7 @@ from .audio import extract_audio, has_video_stream, validate_sound
 from .migration import run_migration_if_needed
 from .mixer import MixerSource
 from .pagination import paginate
+from .pcm_cache import CachedPCMSource, PCMCache
 from .store import SoundStore, parse_tags
 
 logger = logging.getLogger("soundbot")
@@ -87,6 +89,7 @@ class Soundboard(commands.Cog):
         self.store = store
         self.mixer: MixerSource | None = None
         self.volume: float = config.DEFAULT_VOLUME / 100.0
+        self.pcm_cache = PCMCache()
 
     async def cog_load(self) -> None:
         self._save_loop.start()
@@ -115,7 +118,7 @@ class Soundboard(commands.Cog):
             await interaction.guild.voice_client.move_to(channel)
         else:
             vc = await channel.connect()
-            self.mixer = MixerSource()
+            self.mixer = MixerSource(volume=self.volume)
             vc.play(self.mixer)
         await interaction.response.send_message(f"Joined **{channel.name}**.")
 
@@ -159,12 +162,21 @@ class Soundboard(commands.Cog):
             )
             return
 
-        source = discord.FFmpegPCMAudio(
-            entry["file"],
-            options=f"-filter:a volume={self.volume}",
-        )
+        # First play for a file pays the ffmpeg decode cost; every subsequent
+        # press is an in-memory slice. Done via to_thread so a cold miss
+        # doesn't block the event loop.
+        try:
+            pcm_bytes = await asyncio.to_thread(self.pcm_cache.get, entry["file"])
+        except ValueError as exc:
+            logger.warning("decode failed for %s: %s", name, exc)
+            await interaction.response.send_message(
+                f"Failed to decode **{name}**.", ephemeral=True
+            )
+            return
+
+        source = CachedPCMSource(pcm_bytes)
         if self.mixer is None:
-            self.mixer = MixerSource()
+            self.mixer = MixerSource(volume=self.volume)
         self.mixer.add(source)
 
         self.store.increment_play_count(name)
@@ -278,6 +290,10 @@ class Soundboard(commands.Cog):
             )
             return
         self.volume = level / 100.0
+        # Mixer holds its own copy so read() can apply volume without
+        # reaching back into the cog on every frame.
+        if self.mixer is not None:
+            self.mixer.volume = self.volume
         await interaction.response.send_message(f"Volume set to **{level}%**.")
 
     # -- Board --
@@ -369,6 +385,7 @@ class Soundboard(commands.Cog):
     async def removesound(
         self, interaction: discord.Interaction, name: str
     ) -> None:
+        entry = self.store.get(name)
         try:
             self.store.remove(name)
             self.store.save()
@@ -377,6 +394,11 @@ class Soundboard(commands.Cog):
                 f"Sound **{name}** not found.", ephemeral=True
             )
             return
+        # Drop any cached PCM so a re-add under the same filename doesn't
+        # serve stale bytes. `entry` was fetched before remove(), so we
+        # still have the path even though the store entry is gone.
+        if entry is not None:
+            self.pcm_cache.invalidate(entry["file"])
         await interaction.response.send_message(f"Removed sound **{name}**.")
 
     @app_commands.command(name="renamesound", description="Rename a sound")

--- a/soundbot/bot.py
+++ b/soundbot/bot.py
@@ -332,6 +332,20 @@ class Soundboard(commands.Cog):
 
     # -- CRUD commands --
 
+    def _find_existing_by_path(self, path: Path) -> str | None:
+        """Return the name of any store entry whose file is `path`, or None.
+
+        Used by addsound to refuse an upload that would silently overwrite
+        another sound's file. Pre-fix bug: two sounds with the same
+        uploaded filename (different names) would both land at the same
+        dest on disk. The second upload would clobber the first's bytes,
+        corrupting the first entry even though no exception was raised.
+        """
+        for existing_name, existing_entry in self.store.list_sounds():
+            if Path(existing_entry["file"]) == path:
+                return existing_name
+        return None
+
     @app_commands.command(name="addsound", description="Add a new sound")
     @app_commands.describe(
         name="Sound name",
@@ -361,6 +375,24 @@ class Soundboard(commands.Cog):
         if not dest.resolve().is_relative_to(config.SOUNDS_DIR.resolve()):
             await interaction.followup.send("Invalid filename.", ephemeral=True)
             return
+        # Must come before file.save: we never want to write to a path that
+        # another entry already owns. Catches both same-name re-uploads
+        # (refuse, tell user to remove first) and different-name same-filename
+        # collisions (would otherwise corrupt the existing entry).
+        owner = self._find_existing_by_path(dest)
+        if owner is not None:
+            if owner == name.lower():
+                msg = (
+                    f"Sound **{owner}** already uses `{dest.name}`. "
+                    "Remove it first if you want to replace it."
+                )
+            else:
+                msg = (
+                    f"Cannot upload: `{dest.name}` is already in use by sound "
+                    f"**{owner}**. Remove that sound first or rename your upload."
+                )
+            await interaction.followup.send(msg, ephemeral=True)
+            return
         await file.save(dest)
         try:
             if has_video_stream(dest):
@@ -369,6 +401,19 @@ class Soundboard(commands.Cog):
                     dest.unlink(missing_ok=True)
                     await interaction.followup.send(
                         f"A file named `{audio_dest.name}` already exists.",
+                        ephemeral=True,
+                    )
+                    return
+                # Same no-clobber guard as the pre-save check, but for the
+                # extracted audio destination. Covers the case where a store
+                # entry references a file path that was manually deleted off
+                # disk — the .exists() check above would miss it.
+                audio_owner = self._find_existing_by_path(audio_dest)
+                if audio_owner is not None:
+                    dest.unlink(missing_ok=True)
+                    await interaction.followup.send(
+                        f"Cannot upload: `{audio_dest.name}` is already in use "
+                        f"by sound **{audio_owner}**. Remove that sound first.",
                         ephemeral=True,
                     )
                     return
@@ -389,6 +434,11 @@ class Soundboard(commands.Cog):
             # Single save after the batch — add_tag mutates only in-memory state.
             self.store.save()
         except ValueError as exc:
+            # Safe to unlink: _find_existing_by_path above guarantees no
+            # other entry references this path, and the same check fires
+            # for audio_dest post-extraction. (Concurrent /addsound calls
+            # could race around the file.save yield point — that's a
+            # pre-existing TOCTOU limitation, not introduced by this.)
             dest.unlink(missing_ok=True)
             await interaction.followup.send(str(exc), ephemeral=True)
             return

--- a/soundbot/mixer.py
+++ b/soundbot/mixer.py
@@ -15,9 +15,13 @@ class MixerSource(discord.AudioSource):
     Returns empty bytes only when explicitly stopped.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, volume: float = 1.0) -> None:
         self._sources: list = []
         self._stopped: bool = False
+        # Applied sample-wise in read() before clipping. Moved out of the
+        # per-press `ffmpeg -filter:a volume=...` path so playback can skip
+        # ffmpeg entirely — see soundbot/pcm_cache.py.
+        self.volume: float = volume
 
     def add(self, source) -> None:
         self._sources.append(source)
@@ -59,9 +63,11 @@ class MixerSource(discord.AudioSource):
         if not active:
             return SILENCE
 
-        # Clip to int16 range
+        # Apply volume then clip to int16 range. int(x * 1.0) == x for int
+        # x, so volume=1.0 is effectively a pass-through.
+        volume = self.volume
         for i in range(SAMPLES_PER_FRAME):
-            mixed[i] = max(-32768, min(32767, mixed[i]))
+            mixed[i] = max(-32768, min(32767, int(mixed[i] * volume)))
 
         return struct.pack(f"<{SAMPLES_PER_FRAME}h", *mixed)
 

--- a/soundbot/pcm_cache.py
+++ b/soundbot/pcm_cache.py
@@ -1,0 +1,110 @@
+"""In-memory PCM cache to keep ffmpeg off the playback hot path.
+
+The old `_play_sound` path spawned an `ffmpeg` subprocess per press to
+decode + apply `-filter:a volume=...`. On Windows that's 100–350ms of
+avoidable latency for files that never change on disk. This module
+decodes each file exactly once (lazily, on first access) into
+48kHz/stereo/s16le bytes and serves those straight to the mixer on
+subsequent presses.
+
+Volume lives on the mixer now (see MixerSource.volume) so the cache
+doesn't need to be invalidated when `/volume` changes.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Callable
+
+import discord
+
+from .mixer import FRAME_SIZE
+
+
+def decode_to_pcm(file_path: str | Path) -> bytes:
+    """Decode an audio file to 48kHz stereo s16le PCM bytes via ffmpeg.
+
+    Format matches discord.py's voice pipeline exactly so the output can
+    be fed to the mixer with no further conversion. Raises ValueError on
+    decode failure (bad file, ffmpeg missing, timeout).
+    """
+    try:
+        result = subprocess.run(
+            [
+                "ffmpeg",
+                "-v", "error",
+                "-i", str(file_path),
+                "-f", "s16le",
+                "-ar", "48000",
+                "-ac", "2",
+                "-",
+            ],
+            capture_output=True,
+            check=True,
+            timeout=30,
+        )
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        FileNotFoundError,
+    ) as exc:
+        raise ValueError(f"Failed to decode audio: {file_path}") from exc
+    return result.stdout
+
+
+class PCMCache:
+    """Lazy in-memory cache of pre-decoded PCM bytes keyed by file path.
+
+    Threading: `get` calls the decoder synchronously; callers that run
+    inside asyncio should wrap with `asyncio.to_thread` so the event
+    loop stays responsive while a cold miss is decoding.
+    """
+
+    def __init__(
+        self,
+        decoder: Callable[[str | Path], bytes] = decode_to_pcm,
+    ) -> None:
+        self._cache: dict[str, bytes] = {}
+        self._decoder = decoder
+
+    def get(self, file_path: str | Path) -> bytes:
+        key = str(file_path)
+        cached = self._cache.get(key)
+        if cached is not None:
+            return cached
+        data = self._decoder(file_path)
+        self._cache[key] = data
+        return data
+
+    def invalidate(self, file_path: str | Path) -> None:
+        self._cache.pop(str(file_path), None)
+
+    def clear(self) -> None:
+        self._cache.clear()
+
+    def __contains__(self, file_path: str | Path) -> bool:
+        return str(file_path) in self._cache
+
+
+class CachedPCMSource(discord.AudioSource):
+    """Memory-backed PCM source. Zero subprocess cost on the hot path.
+
+    Slices the shared bytes into 20ms frames on demand. A partial final
+    frame is returned as-is; the mixer pads it to FRAME_SIZE with zeros
+    so we don't lose the tail of short sounds.
+    """
+
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+        self._pos = 0
+
+    def read(self) -> bytes:
+        if self._pos >= len(self._data):
+            return b""
+        end = self._pos + FRAME_SIZE
+        chunk = self._data[self._pos:end]
+        self._pos = end
+        return chunk
+
+    def cleanup(self) -> None:
+        pass

--- a/soundbot/pcm_cache.py
+++ b/soundbot/pcm_cache.py
@@ -26,7 +26,10 @@ def decode_to_pcm(file_path: str | Path) -> bytes:
 
     Format matches discord.py's voice pipeline exactly so the output can
     be fed to the mixer with no further conversion. Raises ValueError on
-    decode failure (bad file, ffmpeg missing, timeout).
+    decode failure (bad file, ffmpeg missing, timeout). The ffmpeg stderr
+    tail is included in the exception message so the caller's log line
+    names the actual cause (codec missing, unsupported format, etc.)
+    rather than an opaque "Failed to decode".
     """
     try:
         result = subprocess.run(
@@ -43,12 +46,16 @@ def decode_to_pcm(file_path: str | Path) -> bytes:
             check=True,
             timeout=30,
         )
-    except (
-        subprocess.CalledProcessError,
-        subprocess.TimeoutExpired,
-        FileNotFoundError,
-    ) as exc:
-        raise ValueError(f"Failed to decode audio: {file_path}") from exc
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or b"").decode("utf-8", "replace").strip()
+        detail = f": {stderr[:200]}" if stderr else ""
+        raise ValueError(f"Failed to decode audio: {file_path}{detail}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise ValueError(f"Failed to decode audio: {file_path} (timed out)") from exc
+    except FileNotFoundError as exc:
+        raise ValueError(
+            f"Failed to decode audio: {file_path} (ffmpeg not found)"
+        ) from exc
     return result.stdout
 
 
@@ -58,6 +65,14 @@ class PCMCache:
     Threading: `get` calls the decoder synchronously; callers that run
     inside asyncio should wrap with `asyncio.to_thread` so the event
     loop stays responsive while a cold miss is decoding.
+
+    Memory: no eviction. At 48kHz/stereo/s16le the wire format is
+    ~192KB/sec, so a typical 2s soundboard clip is ~380KB. A library of
+    100 clips fits comfortably in <50MB, which is fine for this bot's
+    expected scale. If the library grows past the low thousands, or if
+    average clip length jumps (music, long samples), swap this for an
+    LRU keyed by byte budget. There is no runtime signal that tells you
+    you've hit the wall — watch RSS.
     """
 
     def __init__(

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -244,6 +244,130 @@ class TestRemoveSoundCacheInvalidation:
         assert cog.pcm_cache._cache == before
 
 
+class TestFindExistingByPath:
+    """Direct unit tests for the _find_existing_by_path helper. The
+    integration tests in TestAddSoundClobberPrevention exercise it
+    through addsound; these cover its contract independently so a future
+    refactor can move the iteration without losing coverage."""
+
+    def test_returns_name_when_path_matches(self, tmp_path):
+        cog = _make_cog(tmp_path)
+        sounds_dir = Path(cog.store._sounds_dir)
+        path = sounds_dir / "alpha.mp3"
+        path.write_bytes(b"")
+        cog.store.add("alpha", path)
+
+        assert cog._find_existing_by_path(path) == "alpha"
+
+    def test_returns_none_for_unowned_path(self, tmp_path):
+        cog = _make_cog(tmp_path)
+        sounds_dir = Path(cog.store._sounds_dir)
+        owned = sounds_dir / "alpha.mp3"
+        owned.write_bytes(b"")
+        cog.store.add("alpha", owned)
+
+        unowned = sounds_dir / "beta.mp3"
+        assert cog._find_existing_by_path(unowned) is None
+
+    def test_returns_none_on_empty_store(self, tmp_path):
+        cog = _make_cog(tmp_path)
+        sounds_dir = Path(cog.store._sounds_dir)
+        assert cog._find_existing_by_path(sounds_dir / "anything.mp3") is None
+
+    def test_finds_match_among_multiple_entries(self, tmp_path):
+        cog = _make_cog(tmp_path)
+        sounds_dir = Path(cog.store._sounds_dir)
+        for name in ("one", "two", "three"):
+            p = sounds_dir / f"{name}.mp3"
+            p.write_bytes(b"")
+            cog.store.add(name, p)
+
+        target = sounds_dir / "two.mp3"
+        assert cog._find_existing_by_path(target) == "two"
+
+    def test_resolves_relative_against_absolute(self, tmp_path, monkeypatch):
+        """The helper resolves both sides — same logical file via different
+        path representations (relative vs absolute) should still match."""
+        cog = _make_cog(tmp_path)
+        sounds_dir = Path(cog.store._sounds_dir)
+
+        # Store an entry with the absolute path
+        abs_path = (sounds_dir / "alpha.mp3").resolve()
+        abs_path.write_bytes(b"")
+        cog.store.add("alpha", abs_path)
+
+        # Look it up by a relative path that resolves to the same place
+        monkeypatch.chdir(sounds_dir)
+        assert cog._find_existing_by_path(Path("alpha.mp3")) == "alpha"
+
+    def test_does_not_raise_on_unusual_paths(self, tmp_path):
+        cog = _make_cog(tmp_path)
+        # Empty store: any input path should return None, never raise
+        assert cog._find_existing_by_path(Path("")) is None
+        assert cog._find_existing_by_path(Path("does/not/exist.mp3")) is None
+
+
+class TestImportSoundsPathConflict:
+    """The same store-entry-path-collision guard that addsound got needs
+    to fire in importsounds too: a fresh download of a Discord soundboard
+    sound must not silently overwrite a file owned by an entry under a
+    different name."""
+
+    def test_path_conflict_blocks_download(self, tmp_path, monkeypatch):
+        from soundbot import config
+
+        cog = _make_cog(tmp_path)
+        sounds_dir = Path(cog.store._sounds_dir)
+        monkeypatch.setattr(config, "SOUNDS_DIR", sounds_dir)
+        monkeypatch.setattr(config, "MAX_DURATION", 60)
+
+        # Pre-populate: an entry under the name "owner" points at the
+        # path that "victim.ogg" would download to. The file is *not* on
+        # disk (so classify_import_sound returns "needs_download"), but
+        # the entry still owns it. Without the guard, we'd silently
+        # overwrite "owner"'s file with the new download.
+        target_path = sounds_dir / "victim.ogg"
+        cog.store.add("owner", target_path)
+
+        # Discord soundboard sound mock — sanitize_name("victim") -> "victim"
+        sound = MagicMock()
+        sound.name = "victim"
+        sound.id = 1234
+
+        save_called = []
+
+        async def fake_save(path):
+            save_called.append(str(path))
+            Path(path).write_bytes(b"new-bytes")
+
+        sound.save = fake_save
+
+        guild = MagicMock()
+        guild.name = "test-guild"
+        guild.fetch_soundboard_sounds = AsyncMock(return_value=[sound])
+
+        interaction = _make_interaction()
+        interaction.guild = guild
+
+        asyncio.run(Soundboard.importsounds.callback(cog, interaction))
+
+        # sound.save was never called — the guard refused before download
+        assert save_called == []
+        # "owner" entry intact
+        assert cog.store.get("owner")["file"] == str(target_path)
+        # No "victim" entry was added
+        assert cog.store.get("victim") is None
+        # The user was told via the followup summary
+        interaction.followup.send.assert_called()
+        # Find the summary call (the one that mentions "Path conflict")
+        summary_calls = [
+            c for c in interaction.followup.send.call_args_list
+            if "Path conflict" in (c.args[0] if c.args else "")
+        ]
+        assert len(summary_calls) == 1
+        assert "owner" in summary_calls[0].args[0]
+
+
 class TestAddSoundClobberPrevention:
     """The error-path unlink in addsound used to clobber another entry's
     file. Pre-existing bug, surfaced in the second review of PR #18.

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,0 +1,276 @@
+"""Wiring tests for Soundboard cog command handlers.
+
+These exist because the PCM-cache refactor (issue #16) added meaningful
+branching to `_play_sound` — error path on decode failure, teardown-race
+re-check after `to_thread`, mixer-volume sync — and the agent review on
+PR #18 flagged that none of it was unit-tested. The discord.py command
+plumbing is mocked rather than stood up; the goal here is to exercise
+the cog's own logic, not Discord's dispatcher.
+"""
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from soundbot.bot import Soundboard
+from soundbot.mixer import MixerSource
+from soundbot.pcm_cache import CachedPCMSource, PCMCache
+from soundbot.store import SoundStore
+
+
+def _make_cog(tmp_path: Path) -> Soundboard:
+    sounds_dir = tmp_path / "sounds"
+    sounds_dir.mkdir()
+    store = SoundStore(
+        metadata_path=tmp_path / "sounds.json",
+        sounds_dir=sounds_dir,
+    )
+    bot = MagicMock()
+    return Soundboard(bot, store)
+
+
+def _make_interaction(*, voice_client=None, response_done: bool = False):
+    interaction = MagicMock()
+    interaction.guild = MagicMock()
+    interaction.guild.voice_client = voice_client
+    interaction.response = MagicMock()
+    interaction.response.is_done.return_value = response_done
+    interaction.response.send_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    interaction.user = MagicMock()
+    interaction.user.__str__ = MagicMock(return_value="test-user")
+    interaction.user.voice = MagicMock()
+    interaction.user.voice.channel = MagicMock()
+    return interaction
+
+
+def _connected_vc():
+    vc = MagicMock()
+    vc.is_connected.return_value = True
+    return vc
+
+
+def _add_sound(cog: Soundboard, name: str, file_name: str = "hello.ogg") -> str:
+    sounds_dir = Path(cog.store._sounds_dir)
+    path = sounds_dir / file_name
+    path.write_bytes(b"")
+    cog.store.add(name, path)
+    return str(path)
+
+
+class TestPlaySoundHappyPath:
+    def test_cached_pcm_source_added_to_mixer(self, tmp_path):
+        cog = _make_cog(tmp_path)
+        _add_sound(cog, "alpha")
+        cog.pcm_cache = PCMCache(decoder=lambda p: b"\x00" * 7680)
+        cog.mixer = MixerSource()
+
+        interaction = _make_interaction(voice_client=_connected_vc())
+        asyncio.run(cog._play_sound(interaction, "alpha"))
+
+        assert len(cog.mixer._sources) == 1
+        assert isinstance(cog.mixer._sources[0], CachedPCMSource)
+        assert cog.store.get("alpha")["play_count"] == 1
+        interaction.response.send_message.assert_called_once()
+
+
+class TestPlaySoundDecodeFailure:
+    def test_decode_failure_replies_ephemeral_and_skips_mixer(self, tmp_path):
+        cog = _make_cog(tmp_path)
+        _add_sound(cog, "broken")
+
+        def boom(path):
+            raise ValueError("unsupported codec: foo")
+
+        cog.pcm_cache = PCMCache(decoder=boom)
+        cog.mixer = MixerSource()
+
+        interaction = _make_interaction(voice_client=_connected_vc())
+        asyncio.run(cog._play_sound(interaction, "broken"))
+
+        interaction.response.send_message.assert_called_once()
+        args, kwargs = interaction.response.send_message.call_args
+        assert "Failed to decode" in args[0]
+        assert "broken" in args[0]
+        assert kwargs.get("ephemeral") is True
+        # Mixer untouched
+        assert cog.mixer._sources == []
+        # Play count NOT incremented — the user heard nothing
+        assert cog.store.get("broken")["play_count"] == 0
+
+
+class TestPlaySoundTeardownRace:
+    def test_mixer_nulled_during_decode_bails_cleanly(self, tmp_path):
+        """If /leave fires while we're awaiting to_thread, the mixer can
+        be None when we resume. Old code lazily created a fresh mixer
+        that was never wired to the voice client — silent drop + leak."""
+        cog = _make_cog(tmp_path)
+        _add_sound(cog, "alpha")
+
+        def decoder_that_tears_down(p):
+            cog.mixer = None
+            return b"\x00" * 3840
+
+        cog.pcm_cache = PCMCache(decoder=decoder_that_tears_down)
+        cog.mixer = MixerSource()
+
+        interaction = _make_interaction(voice_client=_connected_vc())
+        asyncio.run(cog._play_sound(interaction, "alpha"))
+
+        # No lazy mixer recreated
+        assert cog.mixer is None
+        # Play count NOT bumped — the press produced no sound
+        assert cog.store.get("alpha")["play_count"] == 0
+
+    def test_vc_disconnected_during_decode_bails_cleanly(self, tmp_path):
+        cog = _make_cog(tmp_path)
+        _add_sound(cog, "alpha")
+
+        vc = _connected_vc()
+
+        def decoder_that_drops_vc(p):
+            vc.is_connected.return_value = False
+            return b"\x00" * 3840
+
+        cog.pcm_cache = PCMCache(decoder=decoder_that_drops_vc)
+        cog.mixer = MixerSource()
+
+        interaction = _make_interaction(voice_client=vc)
+        asyncio.run(cog._play_sound(interaction, "alpha"))
+
+        # Mixer is intact but no source was added
+        assert len(cog.mixer._sources) == 0
+        assert cog.store.get("alpha")["play_count"] == 0
+
+
+class TestPlaySoundNotInVoice:
+    def test_no_voice_client_replies_with_join_hint(self, tmp_path):
+        cog = _make_cog(tmp_path)
+        _add_sound(cog, "alpha")
+
+        # voice_client=None -> _ensure_voice raises
+        interaction = _make_interaction(voice_client=None)
+        asyncio.run(cog._play_sound(interaction, "alpha"))
+
+        interaction.response.send_message.assert_called_once()
+        args, kwargs = interaction.response.send_message.call_args
+        assert "join" in args[0].lower()
+        assert kwargs.get("ephemeral") is True
+
+
+class TestPlaySoundUnknownSound:
+    def test_unknown_sound_replies_not_found(self, tmp_path):
+        cog = _make_cog(tmp_path)
+        # No sound added
+        interaction = _make_interaction(voice_client=_connected_vc())
+        asyncio.run(cog._play_sound(interaction, "ghost"))
+
+        interaction.response.send_message.assert_called_once()
+        args, kwargs = interaction.response.send_message.call_args
+        assert "ghost" in args[0]
+        assert "not found" in args[0].lower()
+
+
+class TestVolumeCommand:
+    def test_volume_command_syncs_to_mixer(self, tmp_path):
+        cog = _make_cog(tmp_path)
+        cog.mixer = MixerSource(volume=1.0)
+        interaction = _make_interaction()
+
+        asyncio.run(Soundboard.volume.callback(cog, interaction, 50))
+
+        assert cog.volume == 0.5
+        assert cog.mixer.volume == 0.5
+        interaction.response.send_message.assert_called_once()
+
+    def test_volume_command_safe_when_no_mixer(self, tmp_path):
+        cog = _make_cog(tmp_path)
+        # mixer is None until /join is called
+        assert cog.mixer is None
+        interaction = _make_interaction()
+
+        asyncio.run(Soundboard.volume.callback(cog, interaction, 75))
+
+        assert cog.volume == 0.75
+        # Did not raise
+
+    def test_volume_command_rejects_out_of_range(self, tmp_path):
+        cog = _make_cog(tmp_path)
+        cog.mixer = MixerSource(volume=0.5)
+        interaction = _make_interaction()
+
+        asyncio.run(Soundboard.volume.callback(cog, interaction, 150))
+
+        # State unchanged
+        assert cog.volume == 0.5
+        assert cog.mixer.volume == 0.5
+
+
+class TestRemoveSoundCacheInvalidation:
+    def test_removesound_invalidates_cache_entry(self, tmp_path):
+        cog = _make_cog(tmp_path)
+        path = _add_sound(cog, "alpha")
+
+        cog.pcm_cache = PCMCache(decoder=lambda p: b"cached")
+        cog.pcm_cache.get(path)
+        assert path in cog.pcm_cache
+
+        interaction = _make_interaction()
+        asyncio.run(Soundboard.removesound.callback(cog, interaction, "alpha"))
+
+        assert path not in cog.pcm_cache
+        assert cog.store.get("alpha") is None
+
+    def test_removesound_unknown_leaves_cache_alone(self, tmp_path):
+        cog = _make_cog(tmp_path)
+        cog.pcm_cache = PCMCache(decoder=lambda p: b"cached")
+        cog.pcm_cache.get("some/other/path")
+
+        interaction = _make_interaction()
+        asyncio.run(Soundboard.removesound.callback(cog, interaction, "ghost"))
+
+        assert "some/other/path" in cog.pcm_cache
+
+
+class TestAddSoundCacheInvalidation:
+    def test_addsound_invalidates_cache_for_destination(
+        self, tmp_path, monkeypatch
+    ):
+        """Two different /addsound invocations using the same uploaded
+        filename land at the same dest on disk. If the first one was
+        played, its PCM is in the cache — and the second add must wipe
+        that entry or the new sound serves the old bytes."""
+        from soundbot import config
+
+        cog = _make_cog(tmp_path)
+        sounds_dir = Path(cog.store._sounds_dir)
+        monkeypatch.setattr(config, "SOUNDS_DIR", sounds_dir)
+        monkeypatch.setattr(config, "MAX_DURATION", 60)
+
+        dest = sounds_dir / "thing.mp3"
+        cache_key = str(dest)
+        cog.pcm_cache = PCMCache(decoder=lambda p: b"stale")
+        cog.pcm_cache.get(cache_key)
+        assert cache_key in cog.pcm_cache
+
+        attachment = MagicMock(spec=discord.Attachment)
+        attachment.filename = "thing.mp3"
+
+        async def fake_save(path):
+            Path(path).write_bytes(b"new-file")
+
+        attachment.save = fake_save
+
+        monkeypatch.setattr("soundbot.bot.has_video_stream", lambda p: False)
+        monkeypatch.setattr("soundbot.bot.validate_sound", lambda p, d: None)
+
+        interaction = _make_interaction()
+        asyncio.run(
+            Soundboard.addsound.callback(cog, interaction, "thing", attachment)
+        )
+
+        assert cache_key not in cog.pcm_cache

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -196,7 +196,10 @@ class TestVolumeCommand:
         asyncio.run(Soundboard.volume.callback(cog, interaction, 75))
 
         assert cog.volume == 0.75
-        # Did not raise
+        # Did not raise, and still confirmed to the user
+        interaction.response.send_message.assert_called_once()
+        args, _ = interaction.response.send_message.call_args
+        assert "75" in args[0]
 
     def test_volume_command_rejects_out_of_range(self, tmp_path):
         cog = _make_cog(tmp_path)
@@ -229,11 +232,139 @@ class TestRemoveSoundCacheInvalidation:
         cog = _make_cog(tmp_path)
         cog.pcm_cache = PCMCache(decoder=lambda p: b"cached")
         cog.pcm_cache.get("some/other/path")
+        cog.pcm_cache.get("another/path")
+        before = dict(cog.pcm_cache._cache)
 
         interaction = _make_interaction()
         asyncio.run(Soundboard.removesound.callback(cog, interaction, "ghost"))
 
-        assert "some/other/path" in cog.pcm_cache
+        # Stronger than "specific key still present": every entry is
+        # still present and nothing new appeared. Would fail if
+        # removesound ever started invalidating an arbitrary path.
+        assert cog.pcm_cache._cache == before
+
+
+class TestAddSoundClobberPrevention:
+    """The error-path unlink in addsound used to clobber another entry's
+    file. Pre-existing bug, surfaced in the second review of PR #18.
+    Both clobber scenarios are covered:
+
+    - Different name, same uploaded filename: silently corrupts the
+      existing entry even without raising. Must refuse pre-save.
+    - Same name, same filename: `store.add` raises on name collision,
+      error path unlinks the file the *existing* entry still needs.
+      Also refuse pre-save.
+    """
+
+    def _setup(self, tmp_path, monkeypatch):
+        from soundbot import config
+
+        cog = _make_cog(tmp_path)
+        sounds_dir = Path(cog.store._sounds_dir)
+        monkeypatch.setattr(config, "SOUNDS_DIR", sounds_dir)
+        monkeypatch.setattr(config, "MAX_DURATION", 60)
+        monkeypatch.setattr("soundbot.bot.has_video_stream", lambda p: False)
+        monkeypatch.setattr("soundbot.bot.validate_sound", lambda p, d: None)
+        return cog, sounds_dir
+
+    def test_different_name_same_filename_is_refused(
+        self, tmp_path, monkeypatch
+    ):
+        cog, sounds_dir = self._setup(tmp_path, monkeypatch)
+
+        existing_path = sounds_dir / "thing.mp3"
+        existing_path.write_bytes(b"first-content")
+        cog.store.add("first", existing_path)
+
+        attachment = MagicMock(spec=discord.Attachment)
+        attachment.filename = "thing.mp3"
+
+        async def fake_save(path):
+            Path(path).write_bytes(b"second-content")
+
+        attachment.save = fake_save
+
+        interaction = _make_interaction()
+        asyncio.run(
+            Soundboard.addsound.callback(
+                cog, interaction, "second", attachment
+            )
+        )
+
+        # File content is intact — file.save never ran
+        assert existing_path.read_bytes() == b"first-content"
+        # No "second" entry was added
+        assert cog.store.get("second") is None
+        # Original "first" entry intact
+        assert cog.store.get("first")["file"] == str(existing_path)
+        # User was told why
+        interaction.followup.send.assert_called_once()
+        args, kwargs = interaction.followup.send.call_args
+        assert "first" in args[0]
+        assert kwargs.get("ephemeral") is True
+
+    def test_same_name_same_filename_is_refused(
+        self, tmp_path, monkeypatch
+    ):
+        cog, sounds_dir = self._setup(tmp_path, monkeypatch)
+
+        existing_path = sounds_dir / "thing.mp3"
+        existing_path.write_bytes(b"original-content")
+        cog.store.add("existing", existing_path)
+
+        attachment = MagicMock(spec=discord.Attachment)
+        attachment.filename = "thing.mp3"
+
+        async def fake_save(path):
+            Path(path).write_bytes(b"replacement-content")
+
+        attachment.save = fake_save
+
+        interaction = _make_interaction()
+        asyncio.run(
+            Soundboard.addsound.callback(
+                cog, interaction, "existing", attachment
+            )
+        )
+
+        # Original file content preserved — file.save never ran
+        assert existing_path.read_bytes() == b"original-content"
+        # Store entry intact
+        assert cog.store.get("existing") is not None
+        # User told to remove first
+        interaction.followup.send.assert_called_once()
+        args, _ = interaction.followup.send.call_args
+        assert "remove" in args[0].lower() or "already" in args[0].lower()
+
+    def test_different_name_different_filename_succeeds(
+        self, tmp_path, monkeypatch
+    ):
+        """The guard must not false-positive on unrelated uploads."""
+        cog, sounds_dir = self._setup(tmp_path, monkeypatch)
+
+        existing_path = sounds_dir / "alpha.mp3"
+        existing_path.write_bytes(b"alpha-bytes")
+        cog.store.add("alpha", existing_path)
+
+        attachment = MagicMock(spec=discord.Attachment)
+        attachment.filename = "beta.mp3"
+
+        async def fake_save(path):
+            Path(path).write_bytes(b"beta-bytes")
+
+        attachment.save = fake_save
+
+        interaction = _make_interaction()
+        asyncio.run(
+            Soundboard.addsound.callback(
+                cog, interaction, "beta", attachment
+            )
+        )
+
+        assert cog.store.get("beta") is not None
+        assert cog.store.get("alpha") is not None
+        assert (sounds_dir / "beta.mp3").read_bytes() == b"beta-bytes"
+        assert existing_path.read_bytes() == b"alpha-bytes"
 
 
 class TestAddSoundCacheInvalidation:

--- a/tests/test_mixer.py
+++ b/tests/test_mixer.py
@@ -124,6 +124,85 @@ class TestMixerShortFrames:
         assert len(frame) == FRAME_SIZE
 
 
+class TestMixerVolume:
+    def test_default_volume_is_unity(self):
+        """Default volume=1.0 must leave samples untouched."""
+        mixer = MixerSource()
+        assert mixer.volume == 1.0
+        mixer.add(FakeSource(sample_value=1000, num_frames=1))
+
+        frame = mixer.read()
+        samples = struct.unpack(f"<{FRAME_SIZE // 2}h", frame)
+        assert all(s == 1000 for s in samples)
+
+    def test_half_volume_halves_samples(self):
+        mixer = MixerSource(volume=0.5)
+        mixer.add(FakeSource(sample_value=1000, num_frames=1))
+
+        frame = mixer.read()
+        samples = struct.unpack(f"<{FRAME_SIZE // 2}h", frame)
+        assert all(s == 500 for s in samples)
+
+    def test_zero_volume_silences_output(self):
+        mixer = MixerSource(volume=0.0)
+        mixer.add(FakeSource(sample_value=5000, num_frames=1))
+
+        frame = mixer.read()
+        samples = struct.unpack(f"<{FRAME_SIZE // 2}h", frame)
+        assert all(s == 0 for s in samples)
+
+    def test_volume_setter_changes_subsequent_reads(self):
+        """The /volume command mutates `mixer.volume` at runtime."""
+        mixer = MixerSource(volume=1.0)
+        mixer.add(FakeSource(sample_value=4000, num_frames=2))
+
+        frame1 = mixer.read()
+        samples1 = struct.unpack(f"<{FRAME_SIZE // 2}h", frame1)
+        assert all(s == 4000 for s in samples1)
+
+        mixer.volume = 0.25
+        frame2 = mixer.read()
+        samples2 = struct.unpack(f"<{FRAME_SIZE // 2}h", frame2)
+        assert all(s == 1000 for s in samples2)
+
+    def test_volume_applied_after_summing(self):
+        """Volume scales the mix, not each source independently.
+
+        With two sources at 20000 and volume=0.5, the mix is (20000+20000)*0.5
+        = 20000, which stays well under the int16 clip ceiling. If volume
+        were applied per-source before summing, same answer — so use values
+        where it matters: 30000+30000=60000, pre-clip *0.5=30000 (valid),
+        vs per-source 15000+15000=30000 (also valid, same result).
+        The distinguishing case is headroom beyond int16.
+        """
+        mixer = MixerSource(volume=0.5)
+        mixer.add(FakeSource(sample_value=30000, num_frames=1))
+        mixer.add(FakeSource(sample_value=30000, num_frames=1))
+
+        frame = mixer.read()
+        samples = struct.unpack(f"<{FRAME_SIZE // 2}h", frame)
+        # (30000 + 30000) * 0.5 = 30000, no clip
+        assert all(s == 30000 for s in samples)
+
+    def test_clipping_still_applies_with_volume(self):
+        """Volume *boost* (>1.0) must still clip to int16 range."""
+        mixer = MixerSource(volume=2.0)
+        mixer.add(FakeSource(sample_value=20000, num_frames=1))
+
+        frame = mixer.read()
+        samples = struct.unpack(f"<{FRAME_SIZE // 2}h", frame)
+        # 20000 * 2 = 40000, clipped to 32767
+        assert all(s == 32767 for s in samples)
+
+    def test_negative_clipping_with_volume(self):
+        mixer = MixerSource(volume=2.0)
+        mixer.add(FakeSource(sample_value=-20000, num_frames=1))
+
+        frame = mixer.read()
+        samples = struct.unpack(f"<{FRAME_SIZE // 2}h", frame)
+        assert all(s == -32768 for s in samples)
+
+
 class TestMixerCleanup:
     def test_finished_sources_are_cleaned_up(self):
         mixer = MixerSource()

--- a/tests/test_pcm_cache.py
+++ b/tests/test_pcm_cache.py
@@ -34,6 +34,24 @@ class TestDecodeToPcm:
             with pytest.raises(ValueError, match="Failed to decode"):
                 decode_to_pcm("missing.ogg")
 
+    def test_called_process_error_preserves_ffmpeg_stderr(self):
+        """The opaque 'Failed to decode' error was the #1 review nit —
+        we should surface ffmpeg's stderr so logs name the real cause."""
+        err = subprocess.CalledProcessError(
+            1, "ffmpeg", stderr=b"unsupported codec: foo"
+        )
+        with patch("soundbot.pcm_cache.subprocess.run") as mock_run:
+            mock_run.side_effect = err
+            with pytest.raises(ValueError, match="unsupported codec: foo"):
+                decode_to_pcm("bad.ogg")
+
+    def test_called_process_error_with_no_stderr_is_safe(self):
+        err = subprocess.CalledProcessError(1, "ffmpeg", stderr=None)
+        with patch("soundbot.pcm_cache.subprocess.run") as mock_run:
+            mock_run.side_effect = err
+            with pytest.raises(ValueError, match="Failed to decode"):
+                decode_to_pcm("bad.ogg")
+
     def test_timeout_raises_value_error(self):
         with patch("soundbot.pcm_cache.subprocess.run") as mock_run:
             mock_run.side_effect = subprocess.TimeoutExpired("ffmpeg", 30)

--- a/tests/test_pcm_cache.py
+++ b/tests/test_pcm_cache.py
@@ -1,0 +1,190 @@
+import subprocess
+from unittest.mock import patch
+
+import discord
+import pytest
+
+from soundbot.mixer import FRAME_SIZE
+from soundbot.pcm_cache import CachedPCMSource, PCMCache, decode_to_pcm
+
+
+class TestDecodeToPcm:
+    def test_returns_ffmpeg_stdout(self):
+        fake_pcm = b"\x01\x02\x03\x04"
+        with patch("soundbot.pcm_cache.subprocess.run") as mock_run:
+            mock_run.return_value.stdout = fake_pcm
+            out = decode_to_pcm("sounds/hello.ogg")
+        assert out == fake_pcm
+
+    def test_invokes_ffmpeg_with_48k_stereo_s16le(self):
+        with patch("soundbot.pcm_cache.subprocess.run") as mock_run:
+            mock_run.return_value.stdout = b""
+            decode_to_pcm("sounds/hello.ogg")
+        args, _ = mock_run.call_args
+        cmd = args[0]
+        assert cmd[0] == "ffmpeg"
+        assert "-f" in cmd and cmd[cmd.index("-f") + 1] == "s16le"
+        assert "-ar" in cmd and cmd[cmd.index("-ar") + 1] == "48000"
+        assert "-ac" in cmd and cmd[cmd.index("-ac") + 1] == "2"
+        assert cmd[-1] == "-"
+
+    def test_called_process_error_raises_value_error(self):
+        with patch("soundbot.pcm_cache.subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.CalledProcessError(1, "ffmpeg")
+            with pytest.raises(ValueError, match="Failed to decode"):
+                decode_to_pcm("missing.ogg")
+
+    def test_timeout_raises_value_error(self):
+        with patch("soundbot.pcm_cache.subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired("ffmpeg", 30)
+            with pytest.raises(ValueError, match="Failed to decode"):
+                decode_to_pcm("hang.ogg")
+
+    def test_missing_ffmpeg_raises_value_error(self):
+        with patch("soundbot.pcm_cache.subprocess.run") as mock_run:
+            mock_run.side_effect = FileNotFoundError()
+            with pytest.raises(ValueError, match="Failed to decode"):
+                decode_to_pcm("anything.ogg")
+
+
+class TestPCMCache:
+    def test_miss_invokes_decoder(self):
+        calls = []
+
+        def fake_decode(path):
+            calls.append(str(path))
+            return b"decoded"
+
+        cache = PCMCache(decoder=fake_decode)
+        assert cache.get("sounds/a.ogg") == b"decoded"
+        assert calls == ["sounds/a.ogg"]
+
+    def test_hit_does_not_reinvoke_decoder(self):
+        calls = []
+
+        def fake_decode(path):
+            calls.append(str(path))
+            return b"decoded"
+
+        cache = PCMCache(decoder=fake_decode)
+        cache.get("sounds/a.ogg")
+        cache.get("sounds/a.ogg")
+        cache.get("sounds/a.ogg")
+        assert len(calls) == 1
+
+    def test_different_paths_cached_separately(self):
+        def fake_decode(path):
+            return f"bytes-for-{path}".encode()
+
+        cache = PCMCache(decoder=fake_decode)
+        assert cache.get("a.ogg") == b"bytes-for-a.ogg"
+        assert cache.get("b.ogg") == b"bytes-for-b.ogg"
+
+    def test_invalidate_forces_redecode(self):
+        calls = []
+
+        def fake_decode(path):
+            calls.append(str(path))
+            return b"fresh"
+
+        cache = PCMCache(decoder=fake_decode)
+        cache.get("a.ogg")
+        cache.invalidate("a.ogg")
+        cache.get("a.ogg")
+        assert len(calls) == 2
+
+    def test_invalidate_unknown_path_is_noop(self):
+        cache = PCMCache(decoder=lambda p: b"")
+        cache.invalidate("never-seen.ogg")  # must not raise
+
+    def test_clear_empties_cache(self):
+        calls = []
+
+        def fake_decode(path):
+            calls.append(str(path))
+            return b"x"
+
+        cache = PCMCache(decoder=fake_decode)
+        cache.get("a.ogg")
+        cache.get("b.ogg")
+        cache.clear()
+        cache.get("a.ogg")
+        assert len(calls) == 3
+
+    def test_decoder_errors_propagate(self):
+        def fake_decode(path):
+            raise ValueError("decode boom")
+
+        cache = PCMCache(decoder=fake_decode)
+        with pytest.raises(ValueError, match="decode boom"):
+            cache.get("a.ogg")
+
+    def test_decoder_error_does_not_poison_cache(self):
+        # First call fails, second succeeds. A failed decode must not
+        # cache an empty entry or any sentinel.
+        state = {"first": True}
+
+        def fake_decode(path):
+            if state["first"]:
+                state["first"] = False
+                raise ValueError("transient")
+            return b"good"
+
+        cache = PCMCache(decoder=fake_decode)
+        with pytest.raises(ValueError):
+            cache.get("a.ogg")
+        assert cache.get("a.ogg") == b"good"
+
+    def test_contains_reflects_cache_state(self):
+        cache = PCMCache(decoder=lambda p: b"x")
+        assert "a.ogg" not in cache
+        cache.get("a.ogg")
+        assert "a.ogg" in cache
+        cache.invalidate("a.ogg")
+        assert "a.ogg" not in cache
+
+
+class TestCachedPCMSource:
+    def test_is_audio_source(self):
+        source = CachedPCMSource(b"")
+        assert isinstance(source, discord.AudioSource)
+
+    def test_reads_full_frames_in_order(self):
+        data = b"\xAA" * (FRAME_SIZE * 3)
+        source = CachedPCMSource(data)
+
+        frame1 = source.read()
+        frame2 = source.read()
+        frame3 = source.read()
+        assert len(frame1) == FRAME_SIZE
+        assert len(frame2) == FRAME_SIZE
+        assert len(frame3) == FRAME_SIZE
+        assert frame1 + frame2 + frame3 == data
+
+    def test_exhausted_source_returns_empty_bytes(self):
+        source = CachedPCMSource(b"\xAA" * FRAME_SIZE)
+        source.read()
+        assert source.read() == b""
+
+    def test_empty_data_returns_empty_immediately(self):
+        source = CachedPCMSource(b"")
+        assert source.read() == b""
+
+    def test_partial_final_frame_is_returned_raw(self):
+        # Mixer pads short frames with zeros; we should return the
+        # partial tail rather than dropping it.
+        partial_size = FRAME_SIZE // 3
+        data = b"\xAA" * (FRAME_SIZE + partial_size)
+        source = CachedPCMSource(data)
+
+        full = source.read()
+        tail = source.read()
+        assert len(full) == FRAME_SIZE
+        assert len(tail) == partial_size
+        assert source.read() == b""
+
+    def test_cleanup_is_safe(self):
+        source = CachedPCMSource(b"\xAA" * FRAME_SIZE)
+        source.cleanup()  # must not raise
+        # cleanup is a no-op; read still works the same way
+        assert len(source.read()) == FRAME_SIZE


### PR DESCRIPTION
## Summary

- Kills the per-press ffmpeg subprocess. Each file is decoded once to 48kHz/stereo/s16le bytes and every subsequent press slices the shared buffer through a new `CachedPCMSource`.
- Moves volume from `-filter:a volume=...` (per-press ffmpeg flag) onto `MixerSource.volume`, applied sample-wise before clipping. This is what unblocks skipping ffmpeg entirely on the hot path.
- Cold misses run via `asyncio.to_thread` so the first press for a given sound still doesn't block the event loop. `/removesound` invalidates the cache for that file path.

Closes #16.

## Files

- `soundbot/pcm_cache.py` — new module: `decode_to_pcm`, `PCMCache`, `CachedPCMSource`
- `soundbot/mixer.py` — `volume` attribute + sample-wise multiply in `read()`
- `soundbot/bot.py` — `_play_sound` uses cache + `CachedPCMSource`; `/volume` syncs mixer; `/removesound` invalidates
- `tests/test_pcm_cache.py` — 20 new tests (decoder mocking, cache hit/miss/invalidate, frame slicing, partial-frame tail)
- `tests/test_mixer.py` — 7 new volume tests (unity passthrough, scale, silence, boost+clip)

## Expected impact

The issue's analysis points at ffmpeg startup + filter-graph build + first-frame decode as 100-350ms of per-press latency on Windows. After this PR, only the **first** press for a given sound pays that cost — and off the event loop. Hot-path presses do three things: a dict lookup, a `bytes[a:b]` slice, and `list.append`. That should comfortably beat the <20ms p50 target in the acceptance criteria.

The one thing this PR deliberately does *not* do is eager startup warming — that would add multi-second startup time for ~70 sounds. If the first-play hit is noticeable in practice, that's a trivial follow-up (warm in a background task after `on_ready`).

## Test plan

- [x] `tests/test_pcm_cache.py` passes (20 new tests)
- [x] `tests/test_mixer.py` passes (7 new volume tests, all existing tests still green)
- [x] Full suite: 143 passed (was 116 baseline)
- [ ] Manual: join voice, press board buttons back-to-back, confirm the sluggish feel is gone
- [ ] Manual: `/volume 50`, press a button, confirm quieter playback
- [ ] Manual: `/removesound X` then `/addsound X` under same filename, confirm new bytes played (not cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)