### PR TITLE
fix: normalize uploads at add time and explain tag-hidden name collisions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,5 @@ ADMIN_ROLE=Soundbot Admin
 SOUNDS_DIR=./sounds
 METADATA_FILE=./sounds.json
 DEFAULT_VOLUME=50
+TARGET_LUFS=-16
 LOG_FILE=./soundbot.log

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Create a role in your Discord server called **Soundbot Admin** (or whatever you 
 | `/removesound <name>` | Delete a sound |
 | `/renamesound <old> <new>` | Rename a sound |
 | `/listsounds [category] [page]` | List all sounds with play counts |
+| `/importsounds` | Import this server's Discord soundboard sounds (auto-tagged, loudness-normalized) |
 
 ## Adding Sounds
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Create a role in your Discord server called **Soundbot Admin** (or whatever you 
 | `/random [category]` | Play a random sound |
 | `/board` | Show clickable button board of all sounds |
 | `/volume <0-100>` | Set playback volume (default: 50) |
-| `/addsound <name> <file> [category]` | Upload a new sound (max 6.4 seconds) |
+| `/addsound <name> <file> [category] [tags]` | Upload a new sound (max 6.4 seconds; loudness-normalized and auto-tagged with the server's tag) |
 | `/removesound <name>` | Delete a sound |
 | `/renamesound <old> <new>` | Rename a sound |
 | `/listsounds [category] [page]` | List all sounds with play counts |
@@ -119,6 +119,7 @@ All settings are environment variables, configured in `.env`:
 | `SOUNDS_DIR` | `./sounds` | Directory for audio files |
 | `METADATA_FILE` | `./sounds.json` | Path to the metadata JSON file |
 | `DEFAULT_VOLUME` | `50` | Playback volume on startup (0-100) |
+| `TARGET_LUFS` | `-16` | Loudness target for uploads. Sounds louder than this are turned down on upload (never boosted). |
 | `LOG_FILE` | `./soundbot.log` | Log file path (rotating, 5MB, 3 backups) |
 | `SYNC_COMMANDS` | `true` | Sync slash commands per-guild on startup and on join. Set to `false` to skip syncing entirely. |
 

--- a/soundbot/audio.py
+++ b/soundbot/audio.py
@@ -1,6 +1,30 @@
 import json
+import os
+import re
 import subprocess
 from pathlib import Path
+
+# ebur128 prints a summary block on stderr; these pull the integrated
+# loudness and true peak out of it. Same patterns as scripts/measure_loudness.py.
+_INTEGRATED_RE = re.compile(r"Integrated loudness:\s*\n\s*I:\s*(-?\d+\.\d+) LUFS")
+_TRUE_PEAK_RE = re.compile(r"True peak:\s*\n\s*Peak:\s*(-?\d+\.\d+) dBFS")
+
+# Re-encode settings per container for in-place normalization. Keys must
+# cover store._AUDIO_EXTS — an upload that passed validation should never
+# be rejected here for its extension.
+_ENCODE_ARGS: dict[str, list[str]] = {
+    ".ogg": ["-c:a", "libopus", "-b:a", "96k", "-vbr", "on"],
+    ".opus": ["-c:a", "libopus", "-b:a", "96k", "-vbr", "on"],
+    ".webm": ["-c:a", "libopus", "-b:a", "96k", "-vbr", "on"],
+    ".mp3": ["-c:a", "libmp3lame", "-b:a", "128k"],
+    ".m4a": ["-c:a", "aac", "-b:a", "128k"],
+    ".flac": ["-c:a", "flac"],
+    ".wav": ["-c:a", "pcm_s16le"],
+}
+
+# Don't bother re-encoding for a trim smaller than this — the lossy
+# re-encode would cost more fidelity than the level correction gains.
+_SKIP_THRESHOLD_DB = 0.3
 
 
 def get_duration(file_path: Path) -> float:
@@ -111,3 +135,77 @@ def validate_sound(file_path: Path, max_duration: float) -> None:
         raise ValueError(
             f"Sound duration {duration:.1f}s exceeds maximum {max_duration:.1f}s"
         )
+
+
+def measure_loudness(file_path: Path) -> tuple[float, float]:
+    """Return (integrated LUFS, true peak dBFS) of an audio file.
+
+    Raises ValueError if ffmpeg is unavailable, fails, or produces no
+    parseable ebur128 summary (e.g. the file is silent or too short for
+    the meter to gate a single block).
+    """
+    try:
+        result = subprocess.run(
+            [
+                "ffmpeg", "-nostats", "-hide_banner",
+                "-i", str(file_path),
+                "-af", "ebur128=peak=true",
+                "-f", "null", "-",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise ValueError("Loudness measurement timed out") from exc
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        raise ValueError(f"Cannot read audio file: {file_path}") from exc
+
+    integrated = _INTEGRATED_RE.search(result.stderr)
+    true_peak = _TRUE_PEAK_RE.search(result.stderr)
+    if not integrated or not true_peak:
+        raise ValueError(f"Cannot measure loudness of: {file_path}")
+    return float(integrated.group(1)), float(true_peak.group(1))
+
+
+def normalize_loudness(file_path: Path, target_lufs: float) -> float | None:
+    """Attenuate an over-loud file in place down to target_lufs.
+
+    Only ever applies *negative* gain — a file quieter than the target is
+    left untouched (boosting would amplify the noise floor and risk
+    clipping). Returns the gain applied in dB, or None if the file was
+    already at/below target (or within _SKIP_THRESHOLD_DB of it).
+
+    The re-encode goes through a temp file + atomic replace so a crash
+    mid-encode can't leave a truncated sound behind. Raises ValueError on
+    measurement or encode failure; the original file is intact either way.
+    """
+    encode_args = _ENCODE_ARGS.get(file_path.suffix.lower())
+    if encode_args is None:
+        raise ValueError(f"Cannot normalize unsupported format: {file_path.suffix}")
+
+    lufs, _ = measure_loudness(file_path)
+    gain = target_lufs - lufs
+    if gain >= -_SKIP_THRESHOLD_DB:
+        return None
+
+    tmp = file_path.with_name(file_path.stem + ".__norm_tmp__" + file_path.suffix)
+    try:
+        subprocess.run(
+            [
+                "ffmpeg", "-y", "-nostats", "-hide_banner",
+                "-i", str(file_path),
+                "-af", f"volume={gain:.2f}dB",
+                *encode_args,
+                str(tmp),
+            ],
+            capture_output=True,
+            check=True,
+            timeout=60,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as exc:
+        tmp.unlink(missing_ok=True)
+        raise ValueError(f"Failed to normalize: {file_path}") from exc
+    os.replace(tmp, file_path)
+    return gain

--- a/soundbot/audio.py
+++ b/soundbot/audio.py
@@ -9,9 +9,11 @@ from pathlib import Path
 _INTEGRATED_RE = re.compile(r"Integrated loudness:\s*\n\s*I:\s*(-?\d+\.\d+) LUFS")
 _TRUE_PEAK_RE = re.compile(r"True peak:\s*\n\s*Peak:\s*(-?\d+\.\d+) dBFS")
 
-# Re-encode settings per container for in-place normalization. Keys must
-# cover store._AUDIO_EXTS — an upload that passed validation should never
-# be rejected here for its extension.
+# Re-encode settings per container for in-place normalization. Covers every
+# extension scan_folder tracks (store._AUDIO_EXTS, pinned by test) — but
+# /addsound accepts anything ffprobe can read, so an unknown extension
+# degrades to an un-normalized upload rather than a rejected one
+# (normalize_upload catches the ValueError and keeps the file).
 _ENCODE_ARGS: dict[str, list[str]] = {
     ".ogg": ["-c:a", "libopus", "-b:a", "96k", "-vbr", "on"],
     ".opus": ["-c:a", "libopus", "-b:a", "96k", "-vbr", "on"],
@@ -201,11 +203,19 @@ def normalize_loudness(file_path: Path, target_lufs: float) -> float | None:
                 str(tmp),
             ],
             capture_output=True,
+            text=True,
             check=True,
             timeout=60,
         )
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as exc:
+        # The replace lives inside the guard: on Windows a transient lock
+        # on the destination (antivirus, indexer) raises OSError, and this
+        # function's contract is ValueError-or-success — callers like
+        # normalize_upload catch exactly that.
+        os.replace(tmp, file_path)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+        # OSError subsumes FileNotFoundError (ffmpeg not installed).
         tmp.unlink(missing_ok=True)
-        raise ValueError(f"Failed to normalize: {file_path}") from exc
-    os.replace(tmp, file_path)
+        stderr = getattr(exc, "stderr", None)
+        detail = f": {stderr[-300:]}" if stderr else ""
+        raise ValueError(f"Failed to normalize {file_path}{detail}") from exc
     return gain

--- a/soundbot/bot.py
+++ b/soundbot/bot.py
@@ -8,7 +8,12 @@ from discord import app_commands
 from discord.ext import commands, tasks
 
 from . import config
-from .audio import extract_audio, has_video_stream, validate_sound
+from .audio import (
+    extract_audio,
+    has_video_stream,
+    normalize_loudness,
+    validate_sound,
+)
 from .migration import run_migration_if_needed
 from .mixer import MixerSource
 from .pagination import paginate
@@ -59,6 +64,51 @@ def classify_import_sound(
     if dest_exists:
         return "file_conflict"
     return "needs_download"
+
+
+def duplicate_sound_message(name: str, entry: dict) -> str:
+    """Explain a name collision in terms of where the existing sound is visible.
+
+    Names are unique across the whole library, but boards are usually
+    tag-filtered — so "already exists" alone reads as a lie when the
+    existing sound carries no tag for (or a different tag than) the guild
+    the uploader is looking at. Spell out the tags so the user can find it.
+    Pure function so the wording is unit-testable without an Interaction.
+    """
+    # Direct subscript: SoundStore.load() guarantees the tags key exists
+    # on every entry (same invariant classify_import_sound relies on).
+    tags = entry["tags"]
+    if tags:
+        tag_list = ", ".join(f"`{t}`" for t in sorted(tags))
+        return (
+            f"A sound named **{name.lower()}** already exists, tagged {tag_list}. "
+            f"It only shows on boards filtered by those tags — run `/board` with "
+            f"no filter to see it, or pick another name."
+        )
+    return (
+        f"A sound named **{name.lower()}** already exists but has **no tags**, "
+        f"so it never appears on tag-filtered boards. Run `/board` with no "
+        f"filter to see it, `/tag add` to tag it for this server, or pick "
+        f"another name."
+    )
+
+
+def normalize_upload(dest: Path, target_lufs: float) -> float | None:
+    """Best-effort loudness normalization for a just-saved upload.
+
+    Returns the gain applied in dB (or None if the file was already at or
+    below target). Never raises: a sound that can't be normalized is still
+    a playable sound, so measurement/encode failures degrade to keeping
+    the original file rather than refusing the upload.
+    """
+    try:
+        return normalize_loudness(dest, target_lufs)
+    except ValueError:
+        logger.warning(
+            "loudness normalization failed for %s; keeping original", dest,
+            exc_info=True,
+        )
+        return None
 
 
 def _admin_check() -> app_commands.check:
@@ -387,6 +437,29 @@ class Soundboard(commands.Cog):
         except ValueError as exc:
             await interaction.followup.send(str(exc), ephemeral=True)
             return
+        # Name-collision check before any file I/O. store.add would catch
+        # this too, but by then the upload is already on disk — and its
+        # bare "already exists" doesn't explain why the sound is invisible
+        # on tag-filtered boards (the usual reason the user re-uploads it).
+        existing = self.store.get(name)
+        if existing is not None:
+            await interaction.followup.send(
+                duplicate_sound_message(name, existing), ephemeral=True
+            )
+            return
+        # Auto-tag with the guild so the new sound shows up on this
+        # server's tag-filtered board immediately. Same convention as
+        # /importsounds; explicit user tags ride along unchanged.
+        if interaction.guild is not None:
+            try:
+                guild_tag = SoundStore.sanitize_tag(interaction.guild.name)
+                if guild_tag not in tag_list:
+                    tag_list.append(guild_tag)
+            except ValueError:
+                logger.warning(
+                    "guild name %r could not be sanitized into a tag; adding without auto-tag",
+                    interaction.guild.name,
+                )
         # Sanitize filename to prevent path traversal
         safe_name = Path(file.filename).name
         dest = config.SOUNDS_DIR / safe_name
@@ -439,6 +512,9 @@ class Soundboard(commands.Cog):
                 dest.unlink(missing_ok=True)
                 dest = audio_dest
             validate_sound(dest, config.MAX_DURATION)
+            # Normalize before the cache invalidation below so no consumer
+            # can cache the pre-normalization bytes.
+            gain = normalize_upload(dest, config.TARGET_LUFS)
             # Drop any stale cached PCM for this path before the new entry
             # is added. Two distinct sound names uploaded with the same
             # filename land at the same dest on disk, and a previous /play
@@ -461,6 +537,8 @@ class Soundboard(commands.Cog):
             await interaction.followup.send(str(exc), ephemeral=True)
             return
         msg = f"Added sound **{name}**."
+        if gain is not None:
+            msg += f" Normalized {gain:+.1f} dB."
         if tag_list:
             msg += f" Tagged: {', '.join(f'`{t}`' for t in tag_list)}."
         await interaction.followup.send(msg)
@@ -585,6 +663,10 @@ class Soundboard(commands.Cog):
             try:
                 await sound.save(dest)
                 validate_sound(dest, config.MAX_DURATION)
+                # Same upload-time normalization as /addsound — imported
+                # soundboard sounds arrive at whatever level they were
+                # uploaded to Discord at.
+                normalize_upload(dest, config.TARGET_LUFS)
                 self.store.add(
                     key,
                     dest,

--- a/soundbot/bot.py
+++ b/soundbot/bot.py
@@ -457,7 +457,8 @@ class Soundboard(commands.Cog):
                     tag_list.append(guild_tag)
             except ValueError:
                 logger.warning(
-                    "guild name %r could not be sanitized into a tag; adding without auto-tag",
+                    "guild name %r could not be sanitized into a tag; "
+                    "sound will be added without the guild auto-tag",
                     interaction.guild.name,
                 )
         # Sanitize filename to prevent path traversal

--- a/soundbot/config.py
+++ b/soundbot/config.py
@@ -12,4 +12,6 @@ METADATA_FILE: Path = Path(os.getenv("METADATA_FILE", "./sounds.json"))
 DEFAULT_VOLUME: int = int(os.getenv("DEFAULT_VOLUME", "50"))
 LOG_FILE: Path = Path(os.getenv("LOG_FILE", "./soundbot.log"))
 MAX_DURATION: float = 6.4
+# Uploads louder than this are attenuated down to it (never boosted up).
+TARGET_LUFS: float = float(os.getenv("TARGET_LUFS", "-16"))
 SYNC_COMMANDS: bool = os.getenv("SYNC_COMMANDS", "true").lower() == "true"

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -5,7 +5,14 @@ from unittest.mock import patch
 
 import pytest
 
-from soundbot.audio import extract_audio, get_duration, has_video_stream, validate_sound
+from soundbot.audio import (
+    extract_audio,
+    get_duration,
+    has_video_stream,
+    measure_loudness,
+    normalize_loudness,
+    validate_sound,
+)
 
 _has_ffmpeg = shutil.which("ffprobe") is not None
 _skip_no_ffmpeg = pytest.mark.skipif(not _has_ffmpeg, reason="FFmpeg/ffprobe not installed")
@@ -148,3 +155,109 @@ class TestFfprobeTimeout:
             mock_run.side_effect = subprocess.TimeoutExpired(cmd="ffprobe", timeout=10)
             with pytest.raises(ValueError, match="timed out"):
                 get_duration(fake_file)
+
+
+@pytest.fixture()
+def loud_wav(tmp_path):
+    """Generate a 2-second sine well above the -16 LUFS target (~-7 LUFS).
+
+    lavfi's sine source is NOT full-scale — it lands around -21.8 LUFS,
+    i.e. quieter than the target — so tests that need attenuation to
+    actually fire must boost it first.
+    """
+    out = tmp_path / "loud.wav"
+    subprocess.run(
+        [
+            "ffmpeg", "-y", "-f", "lavfi",
+            "-i", "sine=frequency=440:duration=2",
+            "-af", "volume=15dB",
+            str(out),
+        ],
+        capture_output=True,
+        check=True,
+    )
+    return out
+
+
+@pytest.fixture()
+def quiet_wav(tmp_path):
+    """Generate a 2-second sine wave well below any sane loudness target."""
+    out = tmp_path / "quiet.wav"
+    subprocess.run(
+        [
+            "ffmpeg", "-y", "-f", "lavfi",
+            "-i", "sine=frequency=440:duration=2",
+            "-af", "volume=-30dB",
+            str(out),
+        ],
+        capture_output=True,
+        check=True,
+    )
+    return out
+
+
+@_skip_no_ffmpeg
+class TestMeasureLoudness:
+    def test_default_sine_measures_expected_level(self, short_wav):
+        lufs, true_peak = measure_loudness(short_wav)
+        # lavfi's default sine measures ~-21.8 LUFS / -18.1 dBFS true peak.
+        assert -25.0 <= lufs <= -18.0
+        assert -21.0 <= true_peak <= -15.0
+
+    def test_quiet_file_measures_quiet(self, quiet_wav, short_wav):
+        quiet_lufs, _ = measure_loudness(quiet_wav)
+        base_lufs, _ = measure_loudness(short_wav)
+        assert quiet_lufs < base_lufs - 25
+
+    def test_non_audio_raises(self, tmp_path):
+        bad = tmp_path / "junk.mp3"
+        bad.write_bytes(b"not audio")
+        with pytest.raises(ValueError):
+            measure_loudness(bad)
+
+
+class TestMeasureLoudnessTimeout:
+    """No ffmpeg required."""
+
+    def test_timeout_raises_valueerror(self, tmp_path):
+        fake_file = tmp_path / "stuck.mp3"
+        fake_file.write_bytes(b"fake")
+        with patch("soundbot.audio.subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired(cmd="ffmpeg", timeout=30)
+            with pytest.raises(ValueError, match="timed out"):
+                measure_loudness(fake_file)
+
+
+@_skip_no_ffmpeg
+class TestNormalizeLoudness:
+    def test_loud_file_attenuated_to_target(self, loud_wav):
+        gain = normalize_loudness(loud_wav, target_lufs=-16.0)
+        assert gain is not None
+        assert gain < 0  # attenuation only, never boost
+        lufs, _ = measure_loudness(loud_wav)
+        assert abs(lufs - (-16.0)) <= 1.5
+        # Temp file from the atomic-replace dance must not survive.
+        assert list(loud_wav.parent.glob("*__norm_tmp__*")) == []
+
+    def test_quiet_file_left_untouched(self, quiet_wav):
+        before = quiet_wav.read_bytes()
+        assert normalize_loudness(quiet_wav, target_lufs=-16.0) is None
+        assert quiet_wav.read_bytes() == before
+
+    def test_file_within_threshold_left_untouched(self, loud_wav):
+        # Normalize once, then re-normalizing to the same target must be a
+        # no-op — the file is now within the skip threshold of the target.
+        assert normalize_loudness(loud_wav, target_lufs=-16.0) is not None
+        before = loud_wav.read_bytes()
+        assert normalize_loudness(loud_wav, target_lufs=-16.0) is None
+        assert loud_wav.read_bytes() == before
+
+
+class TestNormalizeLoudnessNoFfmpeg:
+    """No ffmpeg required."""
+
+    def test_unsupported_extension_raises(self, tmp_path):
+        f = tmp_path / "sound.aiff"
+        f.write_bytes(b"fake")
+        with pytest.raises(ValueError, match="unsupported format"):
+            normalize_loudness(f, target_lufs=-16.0)

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -261,3 +261,25 @@ class TestNormalizeLoudnessNoFfmpeg:
         f.write_bytes(b"fake")
         with pytest.raises(ValueError, match="unsupported format"):
             normalize_loudness(f, target_lufs=-16.0)
+
+    def test_encode_args_cover_every_tracked_extension(self):
+        """Pin _ENCODE_ARGS ⊇ store._AUDIO_EXTS so a new tracked format
+        can't silently become un-normalizable."""
+        from soundbot.audio import _ENCODE_ARGS
+        from soundbot.store import _AUDIO_EXTS
+
+        assert set(_ENCODE_ARGS) >= _AUDIO_EXTS
+
+
+@_skip_no_ffmpeg
+class TestNormalizeLoudnessReplaceFailure:
+    def test_locked_destination_raises_valueerror_and_cleans_up(self, loud_wav):
+        """On Windows the destination can be transiently locked (antivirus,
+        indexer) — os.replace raising must surface as the documented
+        ValueError, leave the original intact, and not leak the temp file."""
+        before = loud_wav.read_bytes()
+        with patch("soundbot.audio.os.replace", side_effect=PermissionError("locked")):
+            with pytest.raises(ValueError, match="Failed to normalize"):
+                normalize_loudness(loud_wav, target_lufs=-16.0)
+        assert loud_wav.read_bytes() == before
+        assert list(loud_wav.parent.glob("*__norm_tmp__*")) == []

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -389,16 +389,7 @@ class TestAddSoundClobberPrevention:
     """
 
     def _setup(self, tmp_path, monkeypatch):
-        from soundbot import config
-
-        cog = _make_cog(tmp_path)
-        sounds_dir = Path(cog.store._sounds_dir)
-        monkeypatch.setattr(config, "SOUNDS_DIR", sounds_dir)
-        monkeypatch.setattr(config, "MAX_DURATION", 60)
-        monkeypatch.setattr("soundbot.bot.has_video_stream", lambda p: False)
-        monkeypatch.setattr("soundbot.bot.validate_sound", lambda p, d: None)
-        monkeypatch.setattr("soundbot.bot.normalize_loudness", lambda p, t: None)
-        return cog, sounds_dir
+        return _setup_addsound(tmp_path, monkeypatch)
 
     def test_different_name_same_filename_is_refused(
         self, tmp_path, monkeypatch
@@ -508,12 +499,7 @@ class TestAddSoundCacheInvalidation:
         filename land at the same dest on disk. If the first one was
         played, its PCM is in the cache — and the second add must wipe
         that entry or the new sound serves the old bytes."""
-        from soundbot import config
-
-        cog = _make_cog(tmp_path)
-        sounds_dir = Path(cog.store._sounds_dir)
-        monkeypatch.setattr(config, "SOUNDS_DIR", sounds_dir)
-        monkeypatch.setattr(config, "MAX_DURATION", 60)
+        cog, sounds_dir = _setup_addsound(tmp_path, monkeypatch)
 
         dest = sounds_dir / "thing.mp3"
         cache_key = str(dest)
@@ -528,10 +514,6 @@ class TestAddSoundCacheInvalidation:
             Path(path).write_bytes(b"new-file")
 
         attachment.save = fake_save
-
-        monkeypatch.setattr("soundbot.bot.has_video_stream", lambda p: False)
-        monkeypatch.setattr("soundbot.bot.validate_sound", lambda p, d: None)
-        monkeypatch.setattr("soundbot.bot.normalize_loudness", lambda p, t: None)
 
         interaction = _make_interaction()
         asyncio.run(
@@ -719,6 +701,45 @@ class TestAddSoundNormalization:
         args, _ = interaction.followup.send.call_args
         assert "Added sound" in args[0]
         assert "Normalized" not in args[0]
+
+
+class TestImportSoundsNormalization:
+    def test_downloaded_sound_is_normalized(self, tmp_path, monkeypatch):
+        """The upload-time normalization must fire for /importsounds
+        downloads too — imported soundboard sounds arrive at whatever
+        level they were uploaded to Discord at."""
+        from soundbot import config
+
+        calls = []
+
+        def fake_normalize(path, target):
+            calls.append((Path(path), target))
+            return -2.0
+
+        cog, sounds_dir = _setup_addsound(
+            tmp_path, monkeypatch, normalize=fake_normalize
+        )
+
+        sound = MagicMock()
+        sound.name = "fresh"
+        sound.id = 99
+
+        async def fake_save(path):
+            Path(path).write_bytes(b"ogg-bytes")
+
+        sound.save = fake_save
+
+        guild = MagicMock()
+        guild.name = "Test Guild"
+        guild.fetch_soundboard_sounds = AsyncMock(return_value=[sound])
+
+        interaction = _make_interaction()
+        interaction.guild = guild
+
+        asyncio.run(Soundboard.importsounds.callback(cog, interaction))
+
+        assert calls == [(sounds_dir / "fresh.ogg", config.TARGET_LUFS)]
+        assert cog.store.get("fresh") is not None
 
 
 class TestCommandSync:

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -14,7 +14,12 @@ from unittest.mock import AsyncMock, MagicMock
 import discord
 import pytest
 
-from soundbot.bot import Soundboard, deploy_commands, sync_guild_commands
+from soundbot.bot import (
+    Soundboard,
+    deploy_commands,
+    duplicate_sound_message,
+    sync_guild_commands,
+)
 from soundbot.mixer import MixerSource
 from soundbot.pcm_cache import CachedPCMSource, PCMCache
 from soundbot.store import SoundStore
@@ -34,6 +39,9 @@ def _make_cog(tmp_path: Path) -> Soundboard:
 def _make_interaction(*, voice_client=None, response_done: bool = False):
     interaction = MagicMock()
     interaction.guild = MagicMock()
+    # Plain attribute assignment: MagicMock(name=...) would set the mock's
+    # own name, not the guild.name attribute the auto-tag code reads.
+    interaction.guild.name = "Test Guild"
     interaction.guild.voice_client = voice_client
     interaction.response = MagicMock()
     interaction.response.is_done.return_value = response_done
@@ -389,6 +397,7 @@ class TestAddSoundClobberPrevention:
         monkeypatch.setattr(config, "MAX_DURATION", 60)
         monkeypatch.setattr("soundbot.bot.has_video_stream", lambda p: False)
         monkeypatch.setattr("soundbot.bot.validate_sound", lambda p, d: None)
+        monkeypatch.setattr("soundbot.bot.normalize_loudness", lambda p, t: None)
         return cog, sounds_dir
 
     def test_different_name_same_filename_is_refused(
@@ -522,6 +531,7 @@ class TestAddSoundCacheInvalidation:
 
         monkeypatch.setattr("soundbot.bot.has_video_stream", lambda p: False)
         monkeypatch.setattr("soundbot.bot.validate_sound", lambda p, d: None)
+        monkeypatch.setattr("soundbot.bot.normalize_loudness", lambda p, t: None)
 
         interaction = _make_interaction()
         asyncio.run(
@@ -529,6 +539,186 @@ class TestAddSoundCacheInvalidation:
         )
 
         assert cache_key not in cog.pcm_cache
+
+
+def _setup_addsound(tmp_path, monkeypatch, *, normalize=lambda p, t: None):
+    """Shared harness for addsound handler tests: real store + tmp sounds
+    dir, audio helpers stubbed so no ffmpeg runs."""
+    from soundbot import config
+
+    cog = _make_cog(tmp_path)
+    sounds_dir = Path(cog.store._sounds_dir)
+    monkeypatch.setattr(config, "SOUNDS_DIR", sounds_dir)
+    monkeypatch.setattr(config, "MAX_DURATION", 60)
+    monkeypatch.setattr("soundbot.bot.has_video_stream", lambda p: False)
+    monkeypatch.setattr("soundbot.bot.validate_sound", lambda p, d: None)
+    monkeypatch.setattr("soundbot.bot.normalize_loudness", normalize)
+    return cog, sounds_dir
+
+
+def _make_attachment(filename: str) -> MagicMock:
+    attachment = MagicMock(spec=discord.Attachment)
+    attachment.filename = filename
+
+    async def fake_save(path):
+        Path(path).write_bytes(b"audio-bytes")
+
+    attachment.save = MagicMock(side_effect=fake_save)
+    return attachment
+
+
+class TestDuplicateSoundMessage:
+    """Pure-function coverage for the name-collision wording (bug: the old
+    bare "already exists" gave no hint that the sound was merely invisible
+    on the guild's tag-filtered board)."""
+
+    def test_untagged_entry_explains_board_invisibility(self):
+        msg = duplicate_sound_message("What", {"tags": []})
+        assert "what" in msg
+        assert "no tags" in msg
+        assert "/board" in msg
+
+    def test_tagged_entry_lists_tags_sorted(self):
+        msg = duplicate_sound_message("boop", {"tags": ["zeta", "alpha"]})
+        assert "`alpha`, `zeta`" in msg
+        assert "/board" in msg
+
+
+class TestAddSoundDuplicateNamePrecheck:
+    def test_refused_before_file_io_with_tag_hint(self, tmp_path, monkeypatch):
+        cog, sounds_dir = _setup_addsound(tmp_path, monkeypatch)
+        existing_path = sounds_dir / "orig.mp3"
+        existing_path.write_bytes(b"orig")
+        cog.store.add("dupe", existing_path)
+
+        attachment = _make_attachment("unrelated.mp3")
+        interaction = _make_interaction()
+        asyncio.run(
+            Soundboard.addsound.callback(cog, interaction, "dupe", attachment)
+        )
+
+        # Refused before any file I/O — the upload never touched disk.
+        attachment.save.assert_not_called()
+        args, kwargs = interaction.followup.send.call_args
+        assert "no tags" in args[0]
+        assert kwargs.get("ephemeral") is True
+
+
+class TestAddSoundGuildAutoTag:
+    def test_upload_is_tagged_with_guild_and_user_tags(self, tmp_path, monkeypatch):
+        cog, _ = _setup_addsound(tmp_path, monkeypatch)
+        interaction = _make_interaction()  # guild.name = "Test Guild"
+
+        asyncio.run(
+            Soundboard.addsound.callback(
+                cog, interaction, "boop", _make_attachment("boop.mp3"),
+                tags="meme,funny",
+            )
+        )
+
+        assert set(cog.store.get("boop")["tags"]) == {"meme", "funny", "test-guild"}
+        args, _ = interaction.followup.send.call_args
+        assert "`test-guild`" in args[0]
+
+    def test_guild_tag_not_duplicated_when_user_supplies_it(self, tmp_path, monkeypatch):
+        cog, _ = _setup_addsound(tmp_path, monkeypatch)
+        interaction = _make_interaction()
+
+        asyncio.run(
+            Soundboard.addsound.callback(
+                cog, interaction, "boop", _make_attachment("boop.mp3"),
+                tags="test-guild",
+            )
+        )
+
+        assert cog.store.get("boop")["tags"] == ["test-guild"]
+
+    def test_dm_upload_gets_no_guild_tag(self, tmp_path, monkeypatch):
+        cog, _ = _setup_addsound(tmp_path, monkeypatch)
+        interaction = _make_interaction()
+        interaction.guild = None
+
+        asyncio.run(
+            Soundboard.addsound.callback(
+                cog, interaction, "boop", _make_attachment("boop.mp3")
+            )
+        )
+
+        assert cog.store.get("boop")["tags"] == []
+
+    def test_unsanitizable_guild_name_skips_tag_but_uploads(self, tmp_path, monkeypatch):
+        cog, _ = _setup_addsound(tmp_path, monkeypatch)
+        interaction = _make_interaction()
+        interaction.guild.name = "!!!"
+
+        asyncio.run(
+            Soundboard.addsound.callback(
+                cog, interaction, "boop", _make_attachment("boop.mp3")
+            )
+        )
+
+        assert cog.store.get("boop")["tags"] == []
+
+
+class TestAddSoundNormalization:
+    def test_applied_gain_reported_in_message(self, tmp_path, monkeypatch):
+        calls = []
+
+        def fake_normalize(path, target):
+            calls.append((Path(path), target))
+            return -4.5
+
+        cog, sounds_dir = _setup_addsound(
+            tmp_path, monkeypatch, normalize=fake_normalize
+        )
+        interaction = _make_interaction()
+
+        asyncio.run(
+            Soundboard.addsound.callback(
+                cog, interaction, "boop", _make_attachment("boop.mp3")
+            )
+        )
+
+        from soundbot import config
+
+        assert calls == [(sounds_dir / "boop.mp3", config.TARGET_LUFS)]
+        args, _ = interaction.followup.send.call_args
+        assert "Normalized -4.5 dB" in args[0]
+
+    def test_normalization_failure_keeps_upload(self, tmp_path, monkeypatch):
+        def broken_normalize(path, target):
+            raise ValueError("ffmpeg exploded")
+
+        cog, _ = _setup_addsound(
+            tmp_path, monkeypatch, normalize=broken_normalize
+        )
+        interaction = _make_interaction()
+
+        asyncio.run(
+            Soundboard.addsound.callback(
+                cog, interaction, "boop", _make_attachment("boop.mp3")
+            )
+        )
+
+        # A sound that can't be normalized is still a playable sound.
+        assert cog.store.get("boop") is not None
+        args, _ = interaction.followup.send.call_args
+        assert "Added sound" in args[0]
+        assert "Normalized" not in args[0]
+
+    def test_already_at_target_reports_no_gain(self, tmp_path, monkeypatch):
+        cog, _ = _setup_addsound(tmp_path, monkeypatch)  # normalize -> None
+        interaction = _make_interaction()
+
+        asyncio.run(
+            Soundboard.addsound.callback(
+                cog, interaction, "boop", _make_attachment("boop.mp3")
+            )
+        )
+
+        args, _ = interaction.followup.send.call_args
+        assert "Added sound" in args[0]
+        assert "Normalized" not in args[0]
 
 
 class TestCommandSync:


### PR DESCRIPTION
## Summary
Fixes the two bugs found in the field: sounds uploaded since April were never loudness-normalized, and duplicate-name errors were incomprehensible when the existing sound was invisible on tag-filtered boards.

### Upload-time loudness normalization
- New `measure_loudness()` / `normalize_loudness()` in `audio.py` (ported from the one-shot `scripts/` pipeline that had only ever run once, on Apr 12)
- `/addsound` and `/importsounds` now attenuate anything louder than `TARGET_LUFS` (default -16, env-overridable) — attenuate-only, so quiet files are never boosted (no noise-floor amplification, no clipping risk)
- Best-effort: normalization failure logs a warning and keeps the original file rather than refusing the upload; applied gain is reported in the success message
- In-place re-encode goes through a temp file + atomic replace, before the PCM-cache invalidation so stale bytes can't be cached

### Tag-visibility fixes for name collisions
- `/addsound` auto-tags every upload with the guild's tag (same `sanitize_tag(guild.name)` convention as `/importsounds`), so new sounds show up on the server's filtered board immediately
- Duplicate-name check now runs before any file I/O and the error explains *where* the existing sound is visible: lists its tags, or spells out that it has no tags and thus appears on no tag-filtered board

## Test plan
- [x] 189 tests pass (18 new): real-ffmpeg loudness measure/normalize round-trips, attenuate-only + skip-threshold behavior, guild auto-tag (incl. DM and unsanitizable-guild-name paths), duplicate pre-check firing before `file.save`, normalization failure keeping the upload
- [x] Verified end-to-end against real data: a copy of the library's hottest sound (-4.8 LUFS) normalized to -16.4 LUFS

🤖 Generated with [Claude Code](https://claude.com/claude-code)